### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: Text File Generator Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]
@@ -53,6 +56,8 @@ jobs:
   publish:
     needs: build
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    permissions:
+      contents: write
 
     runs-on: ubuntu-latest #OnPremRunners
 


### PR DESCRIPTION
Potential fix for [https://github.com/UTM-Online/UTMO.Text.FileGenerator/security/code-scanning/6](https://github.com/UTM-Online/UTMO.Text.FileGenerator/security/code-scanning/6)

Add explicit `permissions` blocks so `GITHUB_TOKEN` is scoped to only what each job needs.

Best minimal, non-breaking fix in this file:
1. Add a workflow-level default permission of `contents: read` (safe baseline for checkout/build jobs).
2. Add a job-level `permissions` block on `publish` with `contents: write` because that job creates a GitHub release (`gh release create`) and calls GitHub API endpoints.
3. Keep `build` inheriting the root read-only permission since it only checks out/builds/tests/packages and uploads artifacts.

Edit only `.github/workflows/dotnet.yml`:
- Insert root `permissions:` after `name`.
- Insert `permissions:` under `publish:` before steps.

No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
