### PR TITLE
feat: Manifest v2 phases P0-P4 (subject-based references, typed resolution, validation, Manifest Packages, nested manifests & ordering)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,7 +42,7 @@ jobs:
         tag_prefix: "v"
         default_bump: patch
         release_branches: main
-        pre_release_branches: "joirwi/**"
+        pre_release_branches: "joirwi/.*"
         dry_run: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
       

--- a/README.md
+++ b/README.md
@@ -335,6 +335,26 @@ The index-building traversal tracks visited resources (by `ResourceTypeName/Reso
 skips resources that have already been visited in the current traversal, preventing infinite
 recursion when resources contain mutual references in their property graph.
 
+### Manifest v2 foundation (Generation Scope / Manifest Provider)
+
+Work is underway (tracked in [issue #57](https://github.com/UTM-Online/UTMO.Text.FileGenerator/issues/57),
+design in the [Manifests v2 wiki page](https://github.com/UTM-Online/UTMO.Text.FileGenerator/wiki/Manifests.v2))
+to generalize the manifest/reference model so provider packages (DSC, ARM, …) can build typed,
+portable references on top of it. Phase P0 introduces two new abstractions without changing any
+existing behavior:
+
+- **`IGenerationScope`** (`GenerationScope`) — a provider-agnostic coordinate set a reference
+  resolves against. Today only the mandatory `Environment` dimension is populated
+  (`GenerationScope.ForEnvironment(...)`), reproducing v1's environment-only resolution
+  byte-for-byte. Additional coordinates (e.g. a future ARM `DataCenter` dimension) are supported
+  by the type but not yet used by the core pipeline.
+- **`IManifestProvider`** (`LocalManifestProvider`) — a scope-parameterized facade over the
+  existing `IManifestReferenceIndex`. It is registered in DI alongside the index and exists so a
+  future artifact-backed provider (reading a published Manifest Package) can be substituted
+  without changing call sites. The existing `ManifestIndexBuildingPlugin` and
+  `ManifestReferenceResolverPlugin` are unchanged in this phase and continue to use
+  `IManifestReferenceIndex` directly.
+
 ## Security
 
 ### Template Property Exposure

--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ configuration as a dependency.
 
 1. **Index building** – Before any template is rendered, `ManifestIndexBuildingPlugin` walks
    all resources in the environment, calls `ToManifest()` on every `IManifestProducer` with
-   `GenerateManifest = true`, and stores the results in an in-memory index keyed by
-   `(ResourceTypeName, ResourceName)`.
+   `GenerateManifest = true`, and stores the results in an in-memory index. Each manifest is
+   indexed both by its `(ResourceTypeName, ResourceName)` (legacy) and by its
+   `ManifestSubject`/`ParentManifestSubject` (subject-based) identity.
 2. **Resolution** – `ManifestReferenceResolverPlugin` runs before each template render.  For
    every manifest reference declared on the resource it looks up the value from the index and
    injects it into the template context via `AddAdditionalProperty`.
@@ -195,7 +196,9 @@ configuration as a dependency.
 
 ### Declaring a manifest reference
 
-Call `AddManifestReference` inside your resource's constructor or `Initialize` override:
+The preferred way to declare a reference is by **subject** — a stable, author-chosen identity
+for the referenced manifest. Subject-based references resolve from the in-memory index at runtime
+and do **not** require you to hold (or know the concrete type/name of) the referenced resource:
 
 ```csharp
 public class DscNodeConfigurationResource : TemplateResourceBase
@@ -204,16 +207,14 @@ public class DscNodeConfigurationResource : TemplateResourceBase
     {
         NodeName = nodeName;
 
-        // Declare a reference to the "DependsOn" property of another resource's manifest.
-        // The resolved value is injected into the template context under the key "DependsOn".
-        AddManifestReference("DependsOn", new ManifestReference
+        // Reference another manifest purely by its subject. By default the whole manifest is
+        // injected; set PropertyPath to inject a single nested value instead.
+        AddManifestReference("DependsOn", new ManifestReference(dependsOnConfig)
         {
-            ResourceTypeName = "NodeConfiguration",
-            ResourceName     = dependsOnConfig,
-            PropertyPath     = "DependsOn",
+            PropertyPath = "DependsOn",
             // DefaultValue = null means "required" – generation fails if not resolved.
             // Provide a non-null string to make it optional with a fallback.
-            DefaultValue     = null
+            DefaultValue = null,
         });
     }
 
@@ -224,15 +225,45 @@ public class DscNodeConfigurationResource : TemplateResourceBase
     public override string TemplatePath     => "Dsc/NodeConfiguration";
     public override string OutputExtension  => "ps1";
     public override string ResourceName     => NodeName;
+
+    // The subject a *producing* resource is indexed under. Defaults to ResourceName; override to
+    // provide a distinct, unique subject. Use ParentManifestSubject to scope a subject that is
+    // only unique within a parent.
+    public override string? ManifestSubject => NodeName;
 }
 ```
 
-You can also use the generic manifest reference to map the injected value via a `Func` while
-retaining compile-time type safety on the manifest model.  Pass the referenced resource's
-`ResourceTypeName` as the first argument — this must match the `ResourceTypeName` property of
-the resource whose manifest you are referencing (which is the key used by the index):
+Pass an optional second argument to scope the subject under a parent manifest when subjects are
+only unique within a parent:
 
 ```csharp
+AddManifestReference("DependsOn", new ManifestReference("BaseConfig", parentManifest: "ClusterA"));
+```
+
+For strongly typed selection from a subject-identified manifest, use the generic factory:
+
+```csharp
+AddManifestReference("DependsOn", ManifestReference<NodeConfigurationManifest>.BySubject(
+    "BaseConfig",          // subject of the referenced manifest
+    parentManifest: null,  // root scope
+    manifest => manifest.DependsOn));
+```
+
+#### Legacy (type/name) references
+
+Prior to subject-based references, a reference identified its target by the referenced resource's
+`ResourceTypeName` and `ResourceName`. This form still works and is resolved from the same index:
+
+```csharp
+AddManifestReference("DependsOn", new ManifestReference
+{
+    ResourceTypeName = "NodeConfiguration",
+    ResourceName     = dependsOnConfig,
+    PropertyPath     = "DependsOn",
+    DefaultValue     = null,
+});
+
+// Typed legacy form:
 AddManifestReference("DependsOn", new ManifestReference<NodeConfigurationManifest>(
     "NodeConfiguration",  // must match the referenced resource's ResourceTypeName
     dependsOnConfig,

--- a/src/v2/Plug-ins/UTMO.Text.FileGenerator.ResourceManifestGeneration/ManifestPackageEmissionPlugin.cs
+++ b/src/v2/Plug-ins/UTMO.Text.FileGenerator.ResourceManifestGeneration/ManifestPackageEmissionPlugin.cs
@@ -89,8 +89,8 @@ public sealed class ManifestPackageEmissionPlugin : IPipelinePlugin
 
             var distinctProducers = resourceManifests
                                    .Where(r => !string.IsNullOrWhiteSpace(r.Producer.ManifestSubject))
-                                   .DistinctBy(r => (r.Producer.ManifestSubject, r.Producer.ParentManifestSubject))
-                                   .OrderBy(r => r.Producer.ManifestSubject, StringComparer.Ordinal)
+                                   .DistinctBy(r => MakeSubjectDedupeKey(r.Producer.ManifestSubject!, r.Producer.ParentManifestSubject))
+                                   .OrderBy(r => r.Producer.ManifestSubject, StringComparer.OrdinalIgnoreCase)
                                    .ToList();
 
             var entries = new List<ManifestPackageEntry>(distinctProducers.Count);
@@ -136,14 +136,37 @@ public sealed class ManifestPackageEmissionPlugin : IPipelinePlugin
 
             return true;
         }
-        catch (Exception e)
+        catch (Exception e) when (IsRecoverableException(e))
         {
             this.Logger.LogError(e, "Error during Manifest Package emission");
             return false;
         }
     }
 
+    /// <summary>
+    /// Excludes exceptions that indicate a fatal, non-recoverable process state (e.g. out of
+    /// memory, stack overflow) from the "log and return false" handling above, so those
+    /// conditions bubble up instead of being silently swallowed.
+    /// </summary>
+    private static bool IsRecoverableException(Exception exception) =>
+        exception is not (OutOfMemoryException or StackOverflowException
+            or System.Threading.ThreadAbortException or AccessViolationException
+            or AppDomainUnloadedException);
+
     private static string ToManifestResourceTypeSafeName(string resourceTypeName) => resourceTypeName.Split('/').Last();
+
+    /// <summary>
+    /// Builds a case-insensitive de-duplication key for a producer's (subject, parent subject)
+    /// pair, treating a <see langword="null"/> or whitespace-only parent subject as equivalent
+    /// to "no parent" (root scope). This mirrors <c>ManifestReferenceIndex.MakeSubjectKey</c>'s
+    /// case-insensitive, root-scope-normalizing behavior so the emitted package cannot contain
+    /// duplicate/ambiguous entries for what the in-memory index treats as the same manifest.
+    /// </summary>
+    private static string MakeSubjectDedupeKey(string subject, string? parentSubject)
+    {
+        var normalizedParent = string.IsNullOrWhiteSpace(parentSubject) ? string.Empty : parentSubject.Trim();
+        return $"{normalizedParent}|{subject.Trim()}".ToUpperInvariant();
+    }
 
     private static string GenerateSubjectsSource(IReadOnlyList<ManifestPackageEntry> entries)
     {
@@ -164,7 +187,8 @@ public sealed class ManifestPackageEmissionPlugin : IPipelinePlugin
         foreach (var entry in entries)
         {
             var identifier = ToIdentifier(entry.Subject, seenNames);
-            builder.AppendLine($"    public const string {identifier} = \"{EscapeStringLiteral(entry.Subject)}\";");
+            var escapedIdentifier = CSharpKeywords.Contains(identifier) ? "@" + identifier : identifier;
+            builder.AppendLine($"    public const string {escapedIdentifier} = \"{EscapeStringLiteral(entry.Subject)}\";");
         }
 
         builder.AppendLine("}");
@@ -199,6 +223,25 @@ public sealed class ManifestPackageEmissionPlugin : IPipelinePlugin
     }
 
     private static string EscapeStringLiteral(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    /// <summary>
+    /// C# reserved keywords that would fail to compile as a bare identifier in the generated
+    /// <c>Subjects.g.cs</c> class (e.g. a subject that normalizes to <c>class</c> or
+    /// <c>namespace</c>). Escaped with a leading <c>@</c> in <see cref="GenerateSubjectsSource"/>
+    /// so consumers can still reference the constant by its original (unescaped) name.
+    /// </summary>
+    private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed",
+        "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw",
+        "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using",
+        "virtual", "void", "volatile", "while",
+    };
 
     private sealed record ManifestPackageEntry(string Subject, string? ParentSubject, string ResourceTypeName, string ResourceName, string ManifestFile, IManifest? Manifest);
 

--- a/src/v2/Plug-ins/UTMO.Text.FileGenerator.ResourceManifestGeneration/ManifestPackageEmissionPlugin.cs
+++ b/src/v2/Plug-ins/UTMO.Text.FileGenerator.ResourceManifestGeneration/ManifestPackageEmissionPlugin.cs
@@ -1,0 +1,206 @@
+﻿using Microsoft.FeatureManagement;
+
+namespace UTMO.Text.FileGenerator.ResourceManifestGeneration;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using UTMO.Text.FileGenerator.Abstract;
+using UTMO.Text.FileGenerator.Abstract.Constants;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using Formatting = Newtonsoft.Json.Formatting;
+
+/// <summary>
+/// A <see cref="IPipelinePlugin"/> that emits a portable **Manifest Package** describing every
+/// subject-bearing manifest produced for an environment (Manifest v2 phase P3, gap G4): a
+/// <c>manifest-package.json</c> index plus a generated <c>Subjects.g.cs</c> enum-like constants
+/// class, so a consumer in another repository can build an <c>ArtifactManifestProvider</c>
+/// against these files without a source dependency on the producing project.
+/// </summary>
+/// <remarks>
+/// Gated by the <c>ManifestPackaging</c> feature flag, which is additive to (and requires)
+/// <c>ManifestReferenceResolution</c>. Each package entry embeds its manifest payload directly
+/// (mirroring ConfigGen's "a manifest is a dictionary" design tenet), so the package is
+/// self-contained and can be consumed by <c>ArtifactManifestProvider</c> without depending on the
+/// separate per-type <c>&lt;ResourceTypeName&gt;.Manifest.json</c> files emitted by
+/// <see cref="ManifestPipelineProcessor"/> (which remain unchanged for existing consumers).
+/// </remarks>
+[SuppressMessage("ReSharper", "TemplateIsNotCompileTimeConstantProblem")]
+[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
+public sealed class ManifestPackageEmissionPlugin : IPipelinePlugin
+{
+    private const int SchemaVersion = 1;
+
+    public ManifestPackageEmissionPlugin(
+        IGeneralFileWriter writer,
+        ILogger<ManifestPackageEmissionPlugin> logger,
+        ILogger<ManifestPipelineProcessor> resourceWalkLogger,
+        IFeatureManager featureManager)
+    {
+        this.Writer = writer;
+        this.Logger = logger;
+        this.ResourceWalkLogger = resourceWalkLogger;
+        this.FeatureManager = featureManager;
+    }
+
+    public IGeneralFileWriter? Writer { get; init; }
+
+    public ITemplateGenerationEnvironment? Environment { get; init; }
+
+    public PluginPosition Position => PluginPosition.Before;
+
+    public TimeSpan MaxRuntime => TimeSpan.FromMinutes(10);
+
+    public bool RequiresGeneration => false;
+
+    private ILogger<ManifestPackageEmissionPlugin> Logger { get; }
+
+    private ILogger<ManifestPipelineProcessor> ResourceWalkLogger { get; }
+
+    private IFeatureManager FeatureManager { get; }
+
+    public async Task<bool> ProcessPlugin(ITemplateGenerationEnvironment environment)
+    {
+        try
+        {
+            if (!await this.FeatureManager.IsEnabledAsync(FeatureFlags.EnableManifestReferenceResolution) ||
+                !await this.FeatureManager.IsEnabledAsync(FeatureFlags.EnableManifestPackaging))
+            {
+                this.Logger.LogDebug(
+                    "Manifest packaging is disabled ({FeatureFlag}). Skipping package emission for environment '{EnvironmentName}'.",
+                    FeatureFlags.EnableManifestPackaging,
+                    environment.EnvironmentName);
+                return true;
+            }
+
+            if (environment.GeneratorOptions is { GenerateManifest: false, GenerateManifestsOnly: false })
+            {
+                this.Logger.LogInformation("Skipping Manifest Package emission for environment '{EnvironmentName}': manifest generation is disabled.", environment.EnvironmentName);
+                return true;
+            }
+
+            var resourceManifests = new List<(string ResourceTypeName, string ResourceName, IManifestProducer Producer)>();
+
+            foreach (var resource in environment.Resources)
+            {
+                await resource.GenerateResourceManifest(resourceManifests, this.ResourceWalkLogger, this.FeatureManager);
+            }
+
+            var distinctProducers = resourceManifests
+                                   .Where(r => !string.IsNullOrWhiteSpace(r.Producer.ManifestSubject))
+                                   .DistinctBy(r => (r.Producer.ManifestSubject, r.Producer.ParentManifestSubject))
+                                   .OrderBy(r => r.Producer.ManifestSubject, StringComparer.Ordinal)
+                                   .ToList();
+
+            var entries = new List<ManifestPackageEntry>(distinctProducers.Count);
+
+            foreach (var r in distinctProducers)
+            {
+                var manifestData = await r.Producer.ToManifest<IManifest>();
+                entries.Add(new ManifestPackageEntry(
+                    r.Producer.ManifestSubject!,
+                    r.Producer.ParentManifestSubject,
+                    r.ResourceTypeName,
+                    r.ResourceName,
+                    $"{ToManifestResourceTypeSafeName(r.ResourceTypeName)}.Manifest.json",
+                    manifestData));
+            }
+
+            var manifestOutputPath = Path.Join(environment.GeneratorOptions.OutputPath, "Manifests");
+
+            var package = new ManifestPackageDescriptor(
+                SchemaVersion,
+                "local",
+                environment.EnvironmentName,
+                DateTime.UtcNow,
+                entries);
+
+            var packageJson = JsonConvert.SerializeObject(package, Formatting.Indented);
+
+            if (this.Writer is null)
+            {
+                this.Logger.LogError("No writer found for Manifest Package output");
+                return false;
+            }
+
+            await this.Writer.WriteFile(Path.Join(manifestOutputPath, "manifest-package.json"), packageJson, environment.GeneratorOptions.AllowOverwrite);
+
+            var subjectsSource = GenerateSubjectsSource(entries);
+            await this.Writer.WriteFile(Path.Join(manifestOutputPath, "Subjects.g.cs"), subjectsSource, environment.GeneratorOptions.AllowOverwrite);
+
+            this.Logger.LogInformation(
+                "Manifest Package emitted for environment '{EnvironmentName}': {EntryCount} subject(s).",
+                environment.EnvironmentName,
+                entries.Count);
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            this.Logger.LogError(e, "Error during Manifest Package emission");
+            return false;
+        }
+    }
+
+    private static string ToManifestResourceTypeSafeName(string resourceTypeName) => resourceTypeName.Split('/').Last();
+
+    private static string GenerateSubjectsSource(IReadOnlyList<ManifestPackageEntry> entries)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("// <auto-generated>");
+        builder.AppendLine("// Generated by UTMO.Text.FileGenerator Manifest Package emission (Manifest v2 phase P3).");
+        builder.AppendLine("// Do not edit this file directly - regenerate it instead.");
+        builder.AppendLine("// </auto-generated>");
+        builder.AppendLine();
+        builder.AppendLine("namespace ManifestPackage.Generated;");
+        builder.AppendLine();
+        builder.AppendLine("/// <summary>Typo-proof constants for every manifest subject known to this Manifest Package.</summary>");
+        builder.AppendLine("public static class Subjects");
+        builder.AppendLine("{");
+
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var entry in entries)
+        {
+            var identifier = ToIdentifier(entry.Subject, seenNames);
+            builder.AppendLine($"    public const string {identifier} = \"{EscapeStringLiteral(entry.Subject)}\";");
+        }
+
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static string ToIdentifier(string subject, HashSet<string> seenNames)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var c in subject)
+        {
+            sb.Append(char.IsLetterOrDigit(c) ? c : '_');
+        }
+
+        var candidate = sb.ToString();
+
+        if (candidate.Length == 0 || char.IsDigit(candidate[0]))
+        {
+            candidate = "_" + candidate;
+        }
+
+        var unique = candidate;
+        var suffix = 1;
+
+        while (!seenNames.Add(unique))
+        {
+            unique = $"{candidate}_{suffix++}";
+        }
+
+        return unique;
+    }
+
+    private static string EscapeStringLiteral(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    private sealed record ManifestPackageEntry(string Subject, string? ParentSubject, string ResourceTypeName, string ResourceName, string ManifestFile, IManifest? Manifest);
+
+    private sealed record ManifestPackageDescriptor(int SchemaVersion, string ProviderKind, string Environment, DateTime GeneratedAtUtc, IReadOnlyList<ManifestPackageEntry> Entries);
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Integration/ManifestReferenceResolutionIntegrationTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Integration/ManifestReferenceResolutionIntegrationTests.cs
@@ -58,8 +58,10 @@ public class ManifestReferenceResolutionIntegrationTests
 
         host.ExitCode.Should().Be(ExitCodes.Success, "generation should succeed");
 
-        index.BeginEnvironmentScope("TestEnv");
-        index.HasManifestBySubject("R2", null).Should().BeTrue();
+        using (index.BeginEnvironmentScope("TestEnv"))
+        {
+            index.HasManifestBySubject("R2", null).Should().BeTrue();
+        }
 
         sourceResource.InjectedProperties.Should().ContainKey("DependsOn");
         sourceResource.InjectedProperties["DependsOn"].Should().Be("[TypeA]R1");

--- a/src/v2/TestFileGenerator.Core.Tests/Integration/ManifestReferenceResolutionIntegrationTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Integration/ManifestReferenceResolutionIntegrationTests.cs
@@ -25,6 +25,47 @@ namespace TestFileGenerator.Core.Tests.Integration;
 public class ManifestReferenceResolutionIntegrationTests
 {
     // ──────────────────────────────────────────────────────────────────────────
+    // Feature-flag ON – subject-based reference resolves from the index
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task WhenFeatureFlagEnabled_SubjectBasedReferenceIsResolvedBeforeRender()
+    {
+        var rendererMock = new Mock<ITemplateRenderer>();
+        rendererMock.Setup(r => r.AddToGlobalContext(It.IsAny<Dictionary<string, object>>()));
+        rendererMock.Setup(r => r.GenerateFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ITemplateModel>()))
+                    .Returns(Task.CompletedTask);
+
+        var cliOptions = CreateOptions(generateManifestsOnly: false, generateManifest: false);
+
+        // The source resource declares a subject-based reference (no resource type/name coupling).
+        // The referenced producer's default ManifestSubject is its ResourceName ("R2").
+        var sourceResource = new CapturingResource("R1", "TypeA");
+        sourceResource.DeclareManifestReference("DependsOn", new ManifestReference("R2")
+        {
+            PropertyPath = "DependsOn"
+        });
+
+        var referencedResource = new ManifestProducingResource("R2", "TypeB",
+            () => Task.FromResult<IManifest?>(new DependsOnManifest { DependsOn = "[TypeA]R1" }));
+
+        var environment = CreateEnvironment(cliOptions, [sourceResource, referencedResource]);
+
+        var index = new ManifestReferenceIndex();
+        var host  = CreateHost(rendererMock.Object, environment, cliOptions, index, featureFlagEnabled: true);
+
+        await host.StartAsync(CancellationToken.None);
+
+        host.ExitCode.Should().Be(ExitCodes.Success, "generation should succeed");
+
+        index.BeginEnvironmentScope("TestEnv");
+        index.HasManifestBySubject("R2", null).Should().BeTrue();
+
+        sourceResource.InjectedProperties.Should().ContainKey("DependsOn");
+        sourceResource.InjectedProperties["DependsOn"].Should().Be("[TypeA]R1");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Feature-flag OFF – regression / backwards-compatibility
     // ──────────────────────────────────────────────────────────────────────────
 

--- a/src/v2/TestFileGenerator.Core.Tests/Models/ArtifactManifestProviderTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/ArtifactManifestProviderTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="ArtifactManifestProvider"/> (Manifest v2 phase P3, gaps G4/G5):
+/// reads a self-contained Manifest Package written by another project's generation run.
+/// </summary>
+[TestFixture]
+public class ArtifactManifestProviderTests
+{
+    private string _tempDirectory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "ArtifactManifestProviderTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private void WritePackage(string environment, params (string Subject, string? ParentSubject, string ResourceTypeName, string ResourceName, object Manifest)[] entries)
+    {
+        var package = new
+        {
+            SchemaVersion = 1,
+            ProviderKind = "local",
+            Environment = environment,
+            GeneratedAtUtc = DateTime.UtcNow,
+            Entries = entries.Select(e => new
+            {
+                e.Subject,
+                e.ParentSubject,
+                e.ResourceTypeName,
+                e.ResourceName,
+                ManifestFile = $"{e.ResourceTypeName}.Manifest.json",
+                e.Manifest,
+            }),
+        };
+
+        File.WriteAllText(Path.Combine(_tempDirectory, "manifest-package.json"), JsonConvert.SerializeObject(package, Formatting.Indented));
+    }
+
+    [Test]
+    public void Constructor_WhenPackageFileMissing_Throws()
+    {
+        var act = () => new ArtifactManifestProvider(_tempDirectory);
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [Test]
+    public void ProviderKind_IsArtifact()
+    {
+        WritePackage("Production");
+
+        new ArtifactManifestProvider(_tempDirectory).ProviderKind.Should().Be("artifact");
+    }
+
+    [Test]
+    public void TryResolveBySubject_WithMatchingEnvironmentAndSubject_ReturnsManifest()
+    {
+        WritePackage("Production", ("BaseConfig", null, "TypeA", "ResourceA", new { DependsOn = "Network" }));
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        provider.TryResolveBySubject(scope, "BaseConfig", null, "DependsOn", out var value).Should().BeTrue();
+        value!.ToString().Should().Be("Network");
+    }
+
+    [Test]
+    public void TryResolveBySubject_WithMismatchedEnvironment_ReturnsFalse()
+    {
+        WritePackage("Production", ("BaseConfig", null, "TypeA", "ResourceA", new { DependsOn = "Network" }));
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Development");
+
+        provider.TryResolveBySubject(scope, "BaseConfig", null, "DependsOn", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void HasManifestBySubject_WithParentSubject_Distinguishes()
+    {
+        WritePackage(
+            "Production",
+            ("Child", "Parent", "TypeA", "ResourceA", new { Value = "scoped" }),
+            ("Child", null, "TypeB", "ResourceB", new { Value = "unscoped" }));
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        provider.HasManifestBySubject(scope, "Child", "Parent").Should().BeTrue();
+        provider.TryResolveBySubject(scope, "Child", "Parent", "Value", out var scopedValue).Should().BeTrue();
+        scopedValue!.ToString().Should().Be("scoped");
+
+        provider.TryResolveBySubject(scope, "Child", null, "Value", out var unscopedValue).Should().BeTrue();
+        unscopedValue!.ToString().Should().Be("unscoped");
+    }
+
+    [Test]
+    public void TryResolveProperty_LegacyLookup_ResolvesByResourceTypeAndName()
+    {
+        WritePackage("Production", ("BaseConfig", null, "TypeA", "ResourceA", new { Value = "legacy" }));
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        provider.TryResolveProperty(scope, "TypeA", "ResourceA", "Value", out var value).Should().BeTrue();
+        value!.ToString().Should().Be("legacy");
+    }
+
+    [Test]
+    public void StoreManifest_Throws_ProviderIsReadOnly()
+    {
+        WritePackage("Production");
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        var act = () => provider.StoreManifest(scope, "TypeA", "ResourceA", null);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Test]
+    public void StoreManifestBySubject_Throws_ProviderIsReadOnly()
+    {
+        WritePackage("Production");
+        var provider = new ArtifactManifestProvider(_tempDirectory);
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        var act = () => provider.StoreManifestBySubject(scope, "Subject", null, null);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/ArtifactManifestProviderTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/ArtifactManifestProviderTests.cs
@@ -16,7 +16,7 @@ public class ArtifactManifestProviderTests
     [SetUp]
     public void SetUp()
     {
-        _tempDirectory = Path.Combine(Path.GetTempPath(), "ArtifactManifestProviderTests_" + Guid.NewGuid());
+        _tempDirectory = Path.Join(Path.GetTempPath(), "ArtifactManifestProviderTests_" + Guid.NewGuid());
         Directory.CreateDirectory(_tempDirectory);
     }
 
@@ -48,7 +48,7 @@ public class ArtifactManifestProviderTests
             }),
         };
 
-        File.WriteAllText(Path.Combine(_tempDirectory, "manifest-package.json"), JsonConvert.SerializeObject(package, Formatting.Indented));
+        File.WriteAllText(Path.Join(_tempDirectory, "manifest-package.json"), JsonConvert.SerializeObject(package, Formatting.Indented));
     }
 
     [Test]

--- a/src/v2/TestFileGenerator.Core.Tests/Models/GenerationScopeCoordinateRegistryTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/GenerationScopeCoordinateRegistryTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="GenerationScopeCoordinateRegistry"/> (Manifest v2 phase P4, gap G2):
+/// declaration-only coordinate registration with fail-fast conflict detection.
+/// </summary>
+[TestFixture]
+public class GenerationScopeCoordinateRegistryTests
+{
+    private GenerationScopeCoordinateRegistry _registry = null!;
+
+    [SetUp]
+    public void SetUp() => _registry = new GenerationScopeCoordinateRegistry();
+
+    [Test]
+    public void Environment_IsPreRegistered()
+    {
+        _registry.IsRegistered("Environment").Should().BeTrue();
+        _registry.TryGet("Environment", out var coordinate).Should().BeTrue();
+        coordinate!.Required.Should().BeTrue();
+    }
+
+    [Test]
+    public void Register_NewCoordinate_Succeeds()
+    {
+        _registry.Register(new GenerationScopeCoordinate("DataCenter", "arm"));
+
+        _registry.IsRegistered("DataCenter").Should().BeTrue();
+        _registry.TryGet("DataCenter", out var coordinate).Should().BeTrue();
+        coordinate!.OwnerProviderKind.Should().Be("arm");
+    }
+
+    [Test]
+    public void Register_SameCoordinateSameOwnerTwice_IsIdempotent()
+    {
+        _registry.Register(new GenerationScopeCoordinate("DataCenter", "arm"));
+        var act = () => _registry.Register(new GenerationScopeCoordinate("DataCenter", "arm"));
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void Register_SameCoordinateDifferentOwner_ThrowsFailFast()
+    {
+        _registry.Register(new GenerationScopeCoordinate("DataCenter", "arm"));
+        var act = () => _registry.Register(new GenerationScopeCoordinate("DataCenter", "dsc"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void Register_EnvironmentUnderDifferentOwner_ThrowsFailFast()
+    {
+        var act = () => _registry.Register(new GenerationScopeCoordinate("Environment", "arm"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void All_IncludesPreRegisteredAndAddedCoordinates()
+    {
+        _registry.Register(new GenerationScopeCoordinate("DataCenter", "arm"));
+
+        _registry.All.Select(c => c.Name).Should().Contain(new[] { "Environment", "DataCenter" });
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/GenerationScopeTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/GenerationScopeTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="GenerationScope"/>.
+/// </summary>
+[TestFixture]
+public class GenerationScopeTests
+{
+    [Test]
+    public void Constructor_WithNullOrWhitespaceEnvironment_Throws()
+    {
+        var act = () => new GenerationScope("   ");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void ForEnvironment_CreatesScope_WithNoCoordinates()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        scope.Environment.Should().Be("Production");
+        scope.Coordinates.Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetIdentifier_WithNoCoordinates_ReturnsEnvironmentOnly()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+        scope.GetIdentifier().Should().Be("Production");
+    }
+
+    [Test]
+    public void GetIdentifier_WithCoordinates_IsStableAndOrdered()
+    {
+        var scope = new GenerationScope(
+            "Production",
+            new Dictionary<string, string> { ["Region"] = "West", ["DataCenter"] = "EUS" });
+
+        // Coordinates should be ordered deterministically regardless of insertion order.
+        scope.GetIdentifier().Should().Be("Production/DataCenter=EUS/Region=West");
+    }
+
+    [Test]
+    public void TryGetCoordinate_ForEnvironmentDimension_ReturnsEnvironmentValue()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        scope.TryGetCoordinate("Environment", out var value).Should().BeTrue();
+        value.Should().Be("Production");
+    }
+
+    [Test]
+    public void TryGetCoordinate_ForDeclaredCoordinate_ReturnsValue()
+    {
+        var scope = new GenerationScope("Production", new Dictionary<string, string> { ["DataCenter"] = "EUS" });
+
+        scope.TryGetCoordinate("DataCenter", out var value).Should().BeTrue();
+        value.Should().Be("EUS");
+    }
+
+    [Test]
+    public void TryGetCoordinate_ForDeclaredCoordinate_IsCaseInsensitive()
+    {
+        var scope = new GenerationScope("Production", new Dictionary<string, string> { ["DataCenter"] = "EUS" });
+
+        scope.TryGetCoordinate("datacenter", out var value).Should().BeTrue();
+        value.Should().Be("EUS");
+    }
+
+    [Test]
+    public void TryGetCoordinate_ForUnknownDimension_ReturnsFalse()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        scope.TryGetCoordinate("DataCenter", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Test]
+    public void ToString_MatchesGetIdentifier()
+    {
+        var scope = new GenerationScope("Production", new Dictionary<string, string> { ["DataCenter"] = "EUS" });
+        scope.ToString().Should().Be(scope.GetIdentifier());
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/LocalManifestProviderTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/LocalManifestProviderTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="LocalManifestProvider"/>, verifying it faithfully adapts
+/// <see cref="IGenerationScope"/>-based calls onto the underlying <see cref="ManifestReferenceIndex"/>
+/// without changing storage/lookup semantics.
+/// </summary>
+[TestFixture]
+public class LocalManifestProviderTests
+{
+    private ManifestReferenceIndex _index = null!;
+    private LocalManifestProvider _provider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _index = new ManifestReferenceIndex();
+        _provider = new LocalManifestProvider(_index);
+    }
+
+    [Test]
+    public void StoreManifest_ThenTryResolveProperty_RoundTrips()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        _provider.StoreManifest(scope, "TypeA", "ResourceA", new { Value = "hello" });
+
+        _provider.TryResolveProperty(scope, "TypeA", "ResourceA", "Value", out var value).Should().BeTrue();
+        value.Should().Be("hello");
+    }
+
+    [Test]
+    public void HasManifest_ReflectsUnderlyingIndexState()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        _provider.HasManifest(scope, "TypeA", "ResourceA").Should().BeFalse();
+        _provider.StoreManifest(scope, "TypeA", "ResourceA", new { Value = "hello" });
+        _provider.HasManifest(scope, "TypeA", "ResourceA").Should().BeTrue();
+    }
+
+    [Test]
+    public void StoreManifestBySubject_ThenTryResolveBySubject_RoundTrips()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        _provider.StoreManifestBySubject(scope, "Subject1", null, new { Value = "world" });
+
+        _provider.TryResolveBySubject(scope, "Subject1", null, "Value", out var value).Should().BeTrue();
+        value.Should().Be("world");
+        _provider.HasManifestBySubject(scope, "Subject1", null).Should().BeTrue();
+    }
+
+    [Test]
+    public void DifferentEnvironmentScopes_DoNotCollide()
+    {
+        var prod = GenerationScope.ForEnvironment("Production");
+        var dev = GenerationScope.ForEnvironment("Development");
+
+        _provider.StoreManifest(prod, "TypeA", "ResourceA", new { Value = "prod-value" });
+
+        _provider.HasManifest(dev, "TypeA", "ResourceA").Should().BeFalse();
+        _provider.HasManifest(prod, "TypeA", "ResourceA").Should().BeTrue();
+    }
+
+    [Test]
+    public void StoreManifest_WithNullScope_Throws()
+    {
+        var act = () => _provider.StoreManifest(null!, "TypeA", "ResourceA", null);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void TryResolveProperty_WhenNothingStored_ReturnsFalse()
+    {
+        var scope = GenerationScope.ForEnvironment("Production");
+
+        _provider.TryResolveProperty(scope, "TypeA", "ResourceA", "Value", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/LocalManifestProviderTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/LocalManifestProviderTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
 using UTMO.Text.FileGenerator.Models;
 
 namespace TestFileGenerator.Core.Tests.Models;
@@ -80,5 +81,44 @@ public class LocalManifestProviderTests
 
         _provider.TryResolveProperty(scope, "TypeA", "ResourceA", "Value", out var value).Should().BeFalse();
         value.Should().BeNull();
+    }
+
+    [Test]
+    public void ProviderCall_RestoresPreviousAmbientEnvironmentScope()
+    {
+        using var _ = _index.BeginEnvironmentScope("Original");
+        _index.StoreManifest("TypeA", "ResourceA", new { Value = "original" });
+
+        _provider.HasManifest(GenerationScope.ForEnvironment("Scoped"), "DoesNot", "Exist");
+
+        _index.HasManifest("TypeA", "ResourceA").Should().BeTrue();
+    }
+
+    [Test]
+    public void StoreManifest_WithWhitespaceEnvironment_Throws()
+    {
+        var act = () => _provider.StoreManifest(new InvalidGenerationScope("   "), "TypeA", "ResourceA", null);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private sealed class InvalidGenerationScope : IGenerationScope
+    {
+        public InvalidGenerationScope(string environment)
+        {
+            this.Environment = environment;
+        }
+
+        public string Environment { get; }
+
+        public IReadOnlyDictionary<string, string> Coordinates { get; } =
+            new Dictionary<string, string>();
+
+        public bool TryGetCoordinate(string dimension, out string? value)
+        {
+            value = null;
+            return false;
+        }
+
+        public string GetIdentifier() => this.Environment;
     }
 }

--- a/src/v2/TestFileGenerator.Core.Tests/Models/ManifestOrderingResolverTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/ManifestOrderingResolverTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="ManifestOrderingResolver"/> (Manifest v2 phase P4, gap G8):
+/// topological ordering from observed/contributed dependency edges, including cycle detection.
+/// </summary>
+[TestFixture]
+public class ManifestOrderingResolverTests
+{
+    [Test]
+    public void ComputeOrder_WithLinearChain_OrdersDependenciesFirst()
+    {
+        var edges = new[]
+        {
+            new ManifestOrderingEdge("B", "A"), // B depends on A: A must come before B
+            new ManifestOrderingEdge("C", "B"), // C depends on B
+        };
+
+        var order = ManifestOrderingResolver.ComputeOrder(edges);
+
+        order.Should().ContainInOrder("A", "B", "C");
+    }
+
+    [Test]
+    public void ComputeOrder_WithDiamondDependency_ProducesValidOrder()
+    {
+        // D depends on B and C; both B and C depend on A.
+        var edges = new[]
+        {
+            new ManifestOrderingEdge("B", "A"),
+            new ManifestOrderingEdge("C", "A"),
+            new ManifestOrderingEdge("D", "B"),
+            new ManifestOrderingEdge("D", "C"),
+        };
+
+        var order = ManifestOrderingResolver.ComputeOrder(edges).ToList();
+
+        order.Should().HaveCount(4);
+        order.IndexOf("A").Should().BeLessThan(order.IndexOf("B"));
+        order.IndexOf("A").Should().BeLessThan(order.IndexOf("C"));
+        order.IndexOf("B").Should().BeLessThan(order.IndexOf("D"));
+        order.IndexOf("C").Should().BeLessThan(order.IndexOf("D"));
+    }
+
+    [Test]
+    public void ComputeOrder_WithCycle_Throws()
+    {
+        var edges = new[]
+        {
+            new ManifestOrderingEdge("A", "B"),
+            new ManifestOrderingEdge("B", "A"),
+        };
+
+        var act = () => ManifestOrderingResolver.ComputeOrder(edges);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*cycle*");
+    }
+
+    [Test]
+    public void ComputeOrder_WithNoEdges_ReturnsEmpty()
+    {
+        var order = ManifestOrderingResolver.ComputeOrder(Array.Empty<ManifestOrderingEdge>());
+
+        order.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ComputeOrder_FromSinkAndContributors_MergesEdges()
+    {
+        var sink = new InMemoryManifestObservationSink();
+        sink.OnResolved(new ManifestOrderingEdge("B", "A"));
+
+        var contributor = new StaticContributor(new ManifestOrderingEdge("C", "B"));
+
+        var order = ManifestOrderingResolver.ComputeOrder(sink, new[] { contributor });
+
+        order.Should().ContainInOrder("A", "B", "C");
+    }
+
+    private sealed class StaticContributor : IManifestOrderingContributor
+    {
+        private readonly ManifestOrderingEdge _edge;
+
+        public StaticContributor(ManifestOrderingEdge edge) => _edge = edge;
+
+        public IEnumerable<ManifestOrderingEdge> GetEdges()
+        {
+            yield return _edge;
+        }
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/ManifestReferenceInfoTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/ManifestReferenceInfoTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="ManifestReferenceInfo{TManifest}"/> (Manifest v2 phase P1),
+/// covering typed resolution, dangling-subject validation, and type-mismatch validation.
+/// </summary>
+[TestFixture]
+public class ManifestReferenceInfoTests
+{
+    private ManifestReferenceIndex _index = null!;
+    private LocalManifestProvider _provider = null!;
+    private IGenerationScope _scope = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _index = new ManifestReferenceIndex();
+        _provider = new LocalManifestProvider(_index);
+        _scope = GenerationScope.ForEnvironment("Production");
+
+        // Ensure no observation sink is registered unless a test opts in.
+        ManifestReferenceInfo.ObservationSink = null;
+    }
+
+    [TearDown]
+    public void TearDown() => ManifestReferenceInfo.ObservationSink = null;
+
+    [Test]
+    public void GetTypedManifest_WhenSubjectStoredWithMatchingType_ReturnsTypedInstance()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new TestManifest { Value = "hello" });
+
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig");
+
+        var manifest = referenceInfo.GetTypedManifest();
+
+        manifest.Should().NotBeNull();
+        manifest!.Value.Should().Be("hello");
+    }
+
+    [Test]
+    public void GetTypedManifest_WhenSubjectMissing_ReturnsNull()
+    {
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "DoesNotExist");
+
+        referenceInfo.GetTypedManifest().Should().BeNull();
+    }
+
+    [Test]
+    public void GetTypedManifest_WhenStoredTypeMismatches_ReturnsNull()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new OtherManifest());
+
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig");
+
+        referenceInfo.GetTypedManifest().Should().BeNull();
+    }
+
+    [Test]
+    public void ValidateNoThrow_WhenDangling_ReturnsSingleError()
+    {
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "Missing");
+
+        var errors = referenceInfo.ValidateNoThrow().ToList();
+
+        errors.Should().ContainSingle();
+        errors[0].Message.Should().Contain("Dangling");
+    }
+
+    [Test]
+    public void ValidateNoThrow_WhenTypeMismatches_ReturnsTypeMismatchError()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new OtherManifest());
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig");
+
+        var errors = referenceInfo.ValidateNoThrow().ToList();
+
+        errors.Should().ContainSingle();
+        errors[0].Message.Should().Contain("type mismatch");
+    }
+
+    [Test]
+    public void ValidateNoThrow_WhenResolvable_ReturnsNoErrors()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new TestManifest { Value = "ok" });
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig");
+
+        referenceInfo.ValidateNoThrow().Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetTypedManifest_WhenObservationSinkRegistered_RecordsEdge()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new TestManifest { Value = "ok" });
+        var sink = new InMemoryManifestObservationSink();
+        ManifestReferenceInfo.ObservationSink = sink;
+
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig", referrerIdentifier: "referrer-id");
+        referenceInfo.GetTypedManifest();
+
+        sink.Edges.Should().ContainSingle(e => e.ReferrerIdentifier == "referrer-id" && e.ReferencedIdentifier == referenceInfo.GetIdentifier());
+    }
+
+    [Test]
+    public void GetIdentifier_IncludesProviderScopeTypeAndSubject()
+    {
+        var referenceInfo = new ManifestReferenceInfo<TestManifest>(_provider, _scope, "BaseConfig");
+
+        var identifier = referenceInfo.GetIdentifier();
+
+        identifier.Should().Contain("local").And.Contain("Production").And.Contain(nameof(TestManifest)).And.Contain("BaseConfig");
+    }
+
+    private sealed class TestManifest : IManifest
+    {
+        public string Value { get; init; } = string.Empty;
+    }
+
+    private sealed class OtherManifest : IManifest
+    {
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/ManifestReferenceValidationTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/ManifestReferenceValidationTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="ManifestReference.ValidateNoThrow"/> and the typed override on
+/// <see cref="ManifestReference{TSourceManifest}"/> (Manifest v2 phase P2, gaps G3/G10).
+/// </summary>
+[TestFixture]
+public class ManifestReferenceValidationTests
+{
+    private ManifestReferenceIndex _index = null!;
+    private LocalManifestProvider _provider = null!;
+    private IGenerationScope _scope = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _index = new ManifestReferenceIndex();
+        _provider = new LocalManifestProvider(_index);
+        _scope = GenerationScope.ForEnvironment("Production");
+    }
+
+    [Test]
+    public void ValidateNoThrow_UntypedSubjectReference_WhenResolvable_ReturnsNoErrors()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new { Value = "ok" });
+        var reference = new ManifestReference("BaseConfig");
+
+        reference.ValidateNoThrow(_provider, _scope).Should().BeEmpty();
+    }
+
+    [Test]
+    public void ValidateNoThrow_UntypedSubjectReference_WhenDangling_ReturnsError()
+    {
+        var reference = new ManifestReference("Missing");
+
+        reference.ValidateNoThrow(_provider, _scope).Should().ContainSingle();
+    }
+
+    [Test]
+    public void ValidateNoThrow_LegacyReference_WhenDangling_ReturnsError()
+    {
+        var reference = new ManifestReference { ResourceTypeName = "TypeA", ResourceName = "ResourceA" };
+
+        reference.ValidateNoThrow(_provider, _scope).Should().ContainSingle();
+    }
+
+    [Test]
+    public void ValidateNoThrow_TypedReference_WhenTypeMatches_ReturnsNoErrors()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new NetworkManifest { SubnetId = "subnet-1" });
+        var reference = ManifestReference<NetworkManifest>.BySubject("BaseConfig", null, m => m.SubnetId);
+
+        reference.ValidateNoThrow(_provider, _scope).Should().BeEmpty();
+    }
+
+    [Test]
+    public void ValidateNoThrow_TypedReference_WhenTypeMismatches_ReturnsError()
+    {
+        _provider.StoreManifestBySubject(_scope, "BaseConfig", null, new OtherManifest());
+        var reference = ManifestReference<NetworkManifest>.BySubject("BaseConfig", null, m => m.SubnetId);
+
+        var errors = reference.ValidateNoThrow(_provider, _scope).ToList();
+
+        errors.Should().ContainSingle();
+        errors[0].Message.Should().Contain("type mismatch");
+    }
+
+    [Test]
+    public void ValidateNoThrow_TypedReference_WhenDangling_ReturnsError()
+    {
+        var reference = ManifestReference<NetworkManifest>.BySubject("Missing", null, m => m.SubnetId);
+
+        reference.ValidateNoThrow(_provider, _scope).Should().ContainSingle();
+    }
+
+    private sealed class NetworkManifest : IManifest
+    {
+        public string SubnetId { get; init; } = string.Empty;
+    }
+
+    private sealed class OtherManifest : IManifest
+    {
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Models;
+
+namespace TestFileGenerator.Core.Tests.Models;
+
+/// <summary>
+/// Unit tests for subject-based manifest references
+/// (<see cref="ManifestReference(string, string?)"/>) and the subject-keyed index API.
+/// </summary>
+[TestFixture]
+public class SubjectManifestReferenceTests
+{
+    private ManifestReferenceIndex _index = null!;
+
+    [SetUp]
+    public void SetUp() => _index = new ManifestReferenceIndex();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Index: subject storage / lookup
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void HasManifestBySubject_WhenNothingStored_ReturnsFalse() =>
+        _index.HasManifestBySubject("BaseConfig", null).Should().BeFalse();
+
+    [Test]
+    public void StoreAndResolveBySubject_RootScope_Works()
+    {
+        _index.StoreManifestBySubject("BaseConfig", null, new { DependsOn = "[Type]R1" });
+
+        _index.HasManifestBySubject("BaseConfig", null).Should().BeTrue();
+        _index.TryResolveBySubject("BaseConfig", null, "DependsOn", out var value).Should().BeTrue();
+        value.Should().Be("[Type]R1");
+    }
+
+    [Test]
+    public void ResolveBySubject_EmptyPath_ReturnsWholeManifest()
+    {
+        var manifest = new { Value = "v" };
+        _index.StoreManifestBySubject("S", null, manifest);
+
+        _index.TryResolveBySubject("S", null, string.Empty, out var value).Should().BeTrue();
+        value.Should().BeSameAs(manifest);
+    }
+
+    [Test]
+    public void SubjectScoping_ByParent_DoesNotCollide()
+    {
+        _index.StoreManifestBySubject("Config", "ParentA", new { Value = "a" });
+        _index.StoreManifestBySubject("Config", "ParentB", new { Value = "b" });
+
+        _index.TryResolveBySubject("Config", "ParentA", "Value", out var a).Should().BeTrue();
+        _index.TryResolveBySubject("Config", "ParentB", "Value", out var b).Should().BeTrue();
+        a.Should().Be("a");
+        b.Should().Be("b");
+
+        // A root-scoped lookup for the same subject must not resolve either parent-scoped entry.
+        _index.HasManifestBySubject("Config", null).Should().BeFalse();
+    }
+
+    [Test]
+    public void SubjectKey_DoesNotCollideWithLegacyTypeNameKey()
+    {
+        _index.StoreManifest("TypeA", "ResourceA", new { Value = "legacy" });
+        _index.StoreManifestBySubject("ResourceA", "TypeA", new { Value = "subject" });
+
+        _index.TryResolveProperty("TypeA", "ResourceA", "Value", out var legacy).Should().BeTrue();
+        _index.TryResolveBySubject("ResourceA", "TypeA", "Value", out var subject).Should().BeTrue();
+        legacy.Should().Be("legacy");
+        subject.Should().Be("subject");
+    }
+
+    [Test]
+    public void EnvironmentScope_IsolatesSubjects()
+    {
+        _index.BeginEnvironmentScope("Env1");
+        _index.StoreManifestBySubject("S", null, new { Value = "one" });
+
+        _index.BeginEnvironmentScope("Env2");
+        _index.HasManifestBySubject("S", null).Should().BeFalse();
+
+        _index.BeginEnvironmentScope("Env1");
+        _index.TryResolveBySubject("S", null, "Value", out var value).Should().BeTrue();
+        value.Should().Be("one");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ManifestReference constructor
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void Constructor_NullOrWhitespaceSubject_Throws()
+    {
+        var actNull = () => new ManifestReference(null!);
+        var actWhitespace = () => new ManifestReference("   ");
+
+        actNull.Should().Throw<ArgumentException>();
+        actWhitespace.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void Constructor_SetsSubjectAndParent()
+    {
+        var reference = new ManifestReference("BaseConfig", "Parent");
+
+        reference.Subject.Should().Be("BaseConfig");
+        reference.ParentManifest.Should().Be("Parent");
+        reference.PropertyPath.Should().BeEmpty();
+    }
+
+    [Test]
+    public void SubjectReference_ResolvesWholeManifestByDefault()
+    {
+        var manifest = new { DependsOn = "[Type]R1" };
+        _index.StoreManifestBySubject("BaseConfig", null, manifest);
+
+        var reference = new ManifestReference("BaseConfig");
+
+        InvokeTryResolve(reference, _index, out var value).Should().BeTrue();
+        value.Should().BeSameAs(manifest);
+    }
+
+    [Test]
+    public void SubjectReference_WithPropertyPath_ResolvesNestedValue()
+    {
+        _index.StoreManifestBySubject("BaseConfig", null, new { DependsOn = "[Type]R1" });
+
+        var reference = new ManifestReference("BaseConfig") { PropertyPath = "DependsOn" };
+
+        InvokeTryResolve(reference, _index, out var value).Should().BeTrue();
+        value.Should().Be("[Type]R1");
+    }
+
+    [Test]
+    public void GenericSubjectReference_BySubject_MapsTypedValue()
+    {
+        _index.StoreManifestBySubject("BaseConfig", null, new SampleManifest { DependsOn = "[Type]R1" });
+
+        var reference = ManifestReference<SampleManifest>.BySubject(
+            "BaseConfig",
+            null,
+            manifest => manifest.DependsOn);
+
+        InvokeTryResolve(reference, _index, out var value).Should().BeTrue();
+        value.Should().Be("[Type]R1");
+    }
+
+    private static bool InvokeTryResolve(ManifestReference reference, IManifestReferenceIndex index, out object? value)
+    {
+        var method = typeof(ManifestReference).GetMethod(
+            "TryResolveValue",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        var args = new object?[] { index, null };
+        var result = (bool)method.Invoke(reference, args)!;
+        value = args[1];
+        return result;
+    }
+
+    private sealed class SampleManifest : ManifestBase
+    {
+        public required string DependsOn { get; init; }
+    }
+}

--- a/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
@@ -86,15 +86,21 @@ public class SubjectManifestReferenceTests
     [Test]
     public void EnvironmentScope_IsolatesSubjects()
     {
-        _index.BeginEnvironmentScope("Env1");
-        _index.StoreManifestBySubject("S", null, new { Value = "one" });
+        using (_index.BeginEnvironmentScope("Env1"))
+        {
+            _index.StoreManifestBySubject("S", null, new { Value = "one" });
+        }
 
-        _index.BeginEnvironmentScope("Env2");
-        _index.HasManifestBySubject("S", null).Should().BeFalse();
+        using (_index.BeginEnvironmentScope("Env2"))
+        {
+            _index.HasManifestBySubject("S", null).Should().BeFalse();
+        }
 
-        _index.BeginEnvironmentScope("Env1");
-        _index.TryResolveBySubject("S", null, "Value", out var value).Should().BeTrue();
-        value.Should().Be("one");
+        using (_index.BeginEnvironmentScope("Env1"))
+        {
+            _index.TryResolveBySubject("S", null, "Value", out var value).Should().BeTrue();
+            value.Should().Be("one");
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
+++ b/src/v2/TestFileGenerator.Core.Tests/Models/SubjectManifestReferenceTests.cs
@@ -60,6 +60,18 @@ public class SubjectManifestReferenceTests
     }
 
     [Test]
+    public void SubjectScoping_WithSlashInParentOrSubject_DoesNotCollide()
+    {
+        _index.StoreManifestBySubject("c", "a/b", new { Value = "first" });
+        _index.StoreManifestBySubject("b/c", "a", new { Value = "second" });
+
+        _index.TryResolveBySubject("c", "a/b", "Value", out var first).Should().BeTrue();
+        _index.TryResolveBySubject("b/c", "a", "Value", out var second).Should().BeTrue();
+        first.Should().Be("first");
+        second.Should().Be("second");
+    }
+
+    [Test]
     public void SubjectKey_DoesNotCollideWithLegacyTypeNameKey()
     {
         _index.StoreManifest("TypeA", "ResourceA", new { Value = "legacy" });

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Constants/FeatureFlags.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Constants/FeatureFlags.cs
@@ -40,4 +40,31 @@ public static class FeatureFlags
     /// the reference declarations in at least one generation run.
     /// </remarks>
     public const string EnableManifestReferenceResolution = "ManifestReferenceResolution";
+
+    /// <summary>
+    /// The feature flag key for enabling the pre-render manifest reference validation pass
+    /// (Manifest v2 phase P2, gaps G3/G10). Requires <see cref="EnableManifestReferenceResolution"/>
+    /// to also be enabled. When enabled, all declared manifest references are checked for
+    /// dangling subjects and type mismatches before any template is rendered; failures stop
+    /// generation with a descriptive error instead of silently falling back to
+    /// <c>ManifestReference.DefaultValue</c> or surfacing mid-render.
+    /// </summary>
+    public const string EnableManifestReferenceValidation = "ManifestReferenceValidation";
+
+    /// <summary>
+    /// The feature flag key for enabling portable Manifest Package emission (Manifest v2 phase
+    /// P3, gap G4). When enabled, in addition to the existing per-type manifest JSON files, the
+    /// framework emits a <c>manifest-package.json</c> index and a generated <c>Subjects.g.cs</c>
+    /// enum of known subjects, suitable for consumption by other projects via
+    /// <c>ArtifactManifestProvider</c>.
+    /// </summary>
+    public const string EnableManifestPackaging = "ManifestPackaging";
+
+    /// <summary>
+    /// The feature flag key for enabling multi-coordinate Generation Scopes (Manifest v2 phase
+    /// P4, gaps G2/G7/G8/G9). When disabled, scopes are Environment-only and reproduce v1 output
+    /// byte-for-byte. When enabled, provider-declared coordinates (e.g. DataCenter), nested
+    /// manifest resolution, dependency-ordering observation, and scope translation are active.
+    /// </summary>
+    public const string EnableGenerationScopes = "GenerationScopes";
 }

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScope.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScope.cs
@@ -1,0 +1,42 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// A provider-agnostic coordinate set that a <c>ManifestReference</c> resolves against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Environment"/> is the mandatory dimension and preserves v1 behavior exactly: the
+/// manifest index has always been environment-scoped. Additional dimensions are opt-in via
+/// <see cref="Coordinates"/> — e.g. an ARM provider may register a <c>"DataCenter"</c>
+/// coordinate, DSC may register <c>"Node"</c>. The core framework never hard-codes these names;
+/// it only guarantees that <see cref="Environment"/> is always present.
+/// </para>
+/// <para>
+/// A scope with no additional coordinates reproduces v1's single-axis (environment-only)
+/// resolution byte-for-byte.
+/// </para>
+/// </remarks>
+public interface IGenerationScope
+{
+    /// <summary>The mandatory environment dimension of this scope.</summary>
+    string Environment { get; }
+
+    /// <summary>
+    /// Additional provider-declared coordinates that further qualify this scope (e.g.
+    /// <c>{ "DataCenter", "EUS" }</c>). Empty for a v1-parity, environment-only scope.
+    /// </summary>
+    IReadOnlyDictionary<string, string> Coordinates { get; }
+
+    /// <summary>
+    /// Attempts to read the value of the named <paramref name="dimension"/> from this scope.
+    /// <see cref="Environment"/> is always resolvable via the dimension name <c>"Environment"</c>
+    /// in addition to <see cref="Coordinates"/> lookups.
+    /// </summary>
+    bool TryGetCoordinate(string dimension, out string value);
+
+    /// <summary>
+    /// Returns a stable, human-readable identifier for this scope, suitable for use as part of
+    /// a cache/index key (e.g. <c>"env"</c> or <c>"env/DataCenter=EUS"</c>).
+    /// </summary>
+    string GetIdentifier();
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScope.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScope.cs
@@ -32,7 +32,7 @@ public interface IGenerationScope
     /// <see cref="Environment"/> is always resolvable via the dimension name <c>"Environment"</c>
     /// in addition to <see cref="Coordinates"/> lookups.
     /// </summary>
-    bool TryGetCoordinate(string dimension, out string value);
+    bool TryGetCoordinate(string dimension, out string? value);
 
     /// <summary>
     /// Returns a stable, human-readable identifier for this scope, suitable for use as part of

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScopeCoordinate.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IGenerationScopeCoordinate.cs
@@ -1,0 +1,39 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Declares a single Generation Scope coordinate dimension and the provider that owns it
+/// (Manifest v2 phase P4, gap G2). Registration is declaration-only: name, owning provider kind,
+/// and whether the coordinate is required. Value schemas/validators remain provider-owned.
+/// </summary>
+/// <param name="Name">The coordinate dimension name (e.g. <c>"DataCenter"</c>). Matched case-insensitively.</param>
+/// <param name="OwnerProviderKind">The provider kind that owns/declares this coordinate (e.g. <c>"arm"</c>).</param>
+/// <param name="Required">Whether a scope built for <paramref name="OwnerProviderKind"/> must supply this coordinate.</param>
+public sealed record GenerationScopeCoordinate(string Name, string OwnerProviderKind, bool Required = false);
+
+/// <summary>
+/// Base registry for provider-declared Generation Scope coordinates (Manifest v2 phase P4, gap
+/// G2). <see cref="Environment"/> is pre-registered by the base framework. Registering the same
+/// coordinate <see cref="GenerationScopeCoordinate.Name"/> under two different owners is a
+/// fail-fast configuration error, surfaced at registration time (typically application startup)
+/// rather than at scope-build or resolution time.
+/// </summary>
+public interface IGenerationScopeCoordinateRegistry
+{
+    /// <summary>
+    /// Registers <paramref name="coordinate"/>. Throws
+    /// <see cref="InvalidOperationException"/> if a coordinate with the same
+    /// <see cref="GenerationScopeCoordinate.Name"/> is already registered under a different
+    /// <see cref="GenerationScopeCoordinate.OwnerProviderKind"/>. Re-registering an identical
+    /// coordinate (same name and owner) is a no-op.
+    /// </summary>
+    void Register(GenerationScopeCoordinate coordinate);
+
+    /// <summary>Returns whether a coordinate with the given name has been registered.</summary>
+    bool IsRegistered(string name);
+
+    /// <summary>Attempts to retrieve the registered coordinate declaration for <paramref name="name"/>.</summary>
+    bool TryGet(string name, out GenerationScopeCoordinate? coordinate);
+
+    /// <summary>All coordinates registered so far, including the pre-registered <c>"Environment"</c> coordinate.</summary>
+    IReadOnlyCollection<GenerationScopeCoordinate> All { get; }
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestIdentity.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestIdentity.cs
@@ -1,0 +1,32 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Optional generalized identity surface for a manifest payload (Manifest v2, phase P1, see
+/// issue #57 / the <c>Manifests.v2</c> wiki design doc, §4.2). Manifest models are not required
+/// to implement this interface — the framework continues to accept any <see cref="IManifest"/>
+/// payload — but providers that want first-class identity (used by
+/// <see cref="ManifestReferenceInfo{TManifest}"/>, portable Manifest Package emission, and
+/// dependency-ordering observation) should implement it on their manifest base classes
+/// (e.g. <c>ArmResourceManifestBase</c>, <c>DscConfigurationManifestBase</c>).
+/// </summary>
+public interface IManifestIdentity : IManifest
+{
+    /// <summary>The owning provider's kind, e.g. <c>"arm"</c>, <c>"dsc"</c>, <c>"local"</c>.</summary>
+    string ProviderKind { get; }
+
+    /// <summary>The stable subject identity (mirrors <see cref="IManifestProducer.ManifestSubject"/>).</summary>
+    string Subject { get; }
+
+    /// <summary>The optional parent manifest subject that scopes <see cref="Subject"/>.</summary>
+    string? ParentSubject { get; }
+
+    /// <summary>The rendered instance name of the manifest's source resource.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Returns a provider-defined stable address for this manifest (e.g. an ARM resource id, a
+    /// DSC configuration path). Used for diagnostics and cross-provider addressing; the core
+    /// framework does not interpret the returned value.
+    /// </summary>
+    string GetAddress();
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestObservationSink.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestObservationSink.cs
@@ -1,0 +1,35 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// A directed dependency edge between two manifests, identified by their stable identifiers
+/// (see <see cref="ManifestReferenceInfo.GetIdentifier"/> / <see cref="IManifestIdentity"/>).
+/// Manifest v2 phase P4, gap G8.
+/// </summary>
+/// <param name="ReferrerIdentifier">The manifest that declares/holds the reference.</param>
+/// <param name="ReferencedIdentifier">The manifest being referenced (must be produced before <paramref name="ReferrerIdentifier"/>).</param>
+public readonly record struct ManifestOrderingEdge(string ReferrerIdentifier, string ReferencedIdentifier);
+
+/// <summary>
+/// Records dependency edges observed during manifest reference resolution (Manifest v2 phase P4,
+/// gap G8). The base framework calls <see cref="OnResolved"/> every time
+/// <see cref="ManifestReferenceInfo.GetManifest"/> successfully resolves a reference, allowing
+/// providers/consumers to derive a deployment-ordering graph without any manual bookkeeping.
+/// </summary>
+public interface IManifestObservationSink
+{
+    /// <summary>Records that <paramref name="edge"/> was observed during resolution.</summary>
+    void OnResolved(ManifestOrderingEdge edge);
+}
+
+/// <summary>
+/// Optional, provider-owned supplemental ordering contributor (Manifest v2 phase P4, gap G8).
+/// Automatic reference-derived edges (via <see cref="IManifestObservationSink"/>) are the primary
+/// ordering mechanism; a provider may additionally contribute declarative edges for constraints
+/// that are not expressed as manifest references (e.g. "always deploy the network before any
+/// compute resource").
+/// </summary>
+public interface IManifestOrderingContributor
+{
+    /// <summary>Returns supplemental ordering edges to add to the dependency graph.</summary>
+    IEnumerable<ManifestOrderingEdge> GetEdges();
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProducer.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProducer.cs
@@ -35,5 +35,26 @@ namespace UTMO.Text.FileGenerator.Abstract.Contracts
         bool GenerateManifest { get; }
         
         Task<TManifest?> ToManifest<TManifest>() where TManifest : class, IManifest;
+
+        /// <summary>
+        /// A stable, author-chosen identity for this producer's manifest. Manifest references
+        /// declared via <c>new ManifestReference(subject, parentManifest)</c> resolve against
+        /// this value, allowing a reference to be resolved from any location in the app without
+        /// holding the referenced resource instance.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation returns <see langword="null"/>, which means "no subject –
+        /// only legacy (ResourceTypeName/ResourceName) resolution applies". Producers that want
+        /// subject-based resolution should return a non-empty, unique value.
+        /// </remarks>
+        string? ManifestSubject => null;
+
+        /// <summary>
+        /// The optional subject of the parent manifest that scopes this manifest's
+        /// <see cref="ManifestSubject"/>. When <see langword="null"/> the subject is resolved at
+        /// the environment root scope. Use this to disambiguate subjects that are only unique
+        /// within a parent.
+        /// </summary>
+        string? ParentManifestSubject => null;
     }
 }

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProvider.cs
@@ -1,0 +1,53 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Provider-agnostic abstraction over manifest storage and lookup, scoped by
+/// <see cref="IGenerationScope"/> rather than the ambient environment scope used internally by
+/// <c>IManifestReferenceIndex</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the "local" provider seam described by the Manifest v2 design (see the
+/// <c>Manifests.v2</c> wiki page and issue #57, phase P0): <see cref="IManifestProvider"/>
+/// wraps today's in-memory, environment-scoped index so future providers (e.g. an
+/// artifact-backed provider that reads a published Manifest Package) can be substituted without
+/// changing reference-resolution call sites.
+/// </para>
+/// <para>
+/// The member surface intentionally mirrors <c>IManifestReferenceIndex</c>'s existing
+/// capabilities (subject-based and legacy type/name lookups) so the default implementation can be
+/// a thin, behavior-preserving adapter. Typed manifest identity (<c>IManifest</c>-based)
+/// resolution lands in a later phase (P1) as <c>ManifestReferenceInfo&lt;T&gt;</c>.
+/// </para>
+/// </remarks>
+public interface IManifestProvider
+{
+    /// <summary>Stores the manifest data for the given resource within <paramref name="scope"/>.</summary>
+    void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData);
+
+    /// <summary>
+    /// Attempts to navigate <paramref name="propertyPath"/> inside the manifest data previously
+    /// stored for <c>(resourceTypeName, resourceName)</c> within <paramref name="scope"/>.
+    /// </summary>
+    bool TryResolveProperty(IGenerationScope scope, string resourceTypeName, string resourceName, string propertyPath, out object? value);
+
+    /// <summary>Returns whether a manifest has been stored for the given resource within <paramref name="scope"/>.</summary>
+    bool HasManifest(IGenerationScope scope, string resourceTypeName, string resourceName);
+
+    /// <summary>
+    /// Stores the manifest data for the given <paramref name="subject"/> (optionally scoped by
+    /// <paramref name="parentManifest"/>) within <paramref name="scope"/>.
+    /// </summary>
+    void StoreManifestBySubject(IGenerationScope scope, string subject, string? parentManifest, object? manifestData);
+
+    /// <summary>
+    /// Attempts to navigate <paramref name="propertyPath"/> inside the manifest data stored for
+    /// <paramref name="subject"/> (optionally scoped by <paramref name="parentManifest"/>) within
+    /// <paramref name="scope"/>. An empty <paramref name="propertyPath"/> resolves the entire
+    /// manifest object.
+    /// </summary>
+    bool TryResolveBySubject(IGenerationScope scope, string subject, string? parentManifest, string propertyPath, out object? value);
+
+    /// <summary>Returns whether a manifest has been stored for the given subject/parent within <paramref name="scope"/>.</summary>
+    bool HasManifestBySubject(IGenerationScope scope, string subject, string? parentManifest);
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/IManifestProvider.cs
@@ -22,6 +22,13 @@ namespace UTMO.Text.FileGenerator.Abstract.Contracts;
 /// </remarks>
 public interface IManifestProvider
 {
+    /// <summary>
+    /// A stable, human-readable identity for this provider's kind (e.g. <c>"local"</c>,
+    /// <c>"artifact"</c>, or a provider-specific value such as <c>"arm"</c>/<c>"dsc"</c>). Used
+    /// by <see cref="ManifestReferenceInfo"/> identifiers and portable Manifest Package metadata.
+    /// </summary>
+    string ProviderKind { get; }
+
     /// <summary>Stores the manifest data for the given resource within <paramref name="scope"/>.</summary>
     void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData);
 
@@ -50,4 +57,14 @@ public interface IManifestProvider
 
     /// <summary>Returns whether a manifest has been stored for the given subject/parent within <paramref name="scope"/>.</summary>
     bool HasManifestBySubject(IGenerationScope scope, string subject, string? parentManifest);
+
+    /// <summary>
+    /// Attempts to retrieve the raw manifest object previously stored for
+    /// <paramref name="subject"/> (optionally scoped by <paramref name="parentManifest"/>) within
+    /// <paramref name="scope"/>, without navigating a property path. This is the entry point used
+    /// by <see cref="ManifestReferenceInfo{TManifest}"/> (phase P1) for typed resolution: callers
+    /// perform their own type check/cast against the returned object.
+    /// </summary>
+    bool TryGetManifest(IGenerationScope scope, string subject, string? parentManifest, out object? manifestData) =>
+        this.TryResolveBySubject(scope, subject, parentManifest, string.Empty, out manifestData);
 }

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/INestedManifest.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/INestedManifest.cs
@@ -1,0 +1,14 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Typed nesting contract (Manifest v2 phase P4, gap G7): a manifest that is scoped beneath a
+/// parent manifest can expose that parent in a strongly typed way, mirroring ConfigGen's
+/// subjects-chain nesting.
+/// </summary>
+/// <typeparam name="TParent">The parent manifest's identity type.</typeparam>
+public interface INestedManifest<out TParent> : IManifest
+    where TParent : class, IManifest
+{
+    /// <summary>Returns this manifest's parent. May resolve lazily via the owning provider.</summary>
+    TParent GetParentManifest();
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ITranslatableScope.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ITranslatableScope.cs
@@ -1,0 +1,22 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Optional translation seam (Manifest v2 phase P4, gap G9) that lets an
+/// <see cref="IManifestProvider"/> map a foreign provider's environment/coordinate aliases onto
+/// the local <see cref="IGenerationScope"/> before lookup. Implement this on a provider when its
+/// scope vocabulary differs from the requesting scope's (e.g. an external Manifest Package uses
+/// <c>"Region"</c> where the local scope uses <c>"DataCenter"</c>).
+/// </summary>
+/// <remarks>
+/// Providers that do not implement this interface are treated as requiring no translation — the
+/// requesting scope is used as-is. This preserves v1/byte-for-byte behavior for the default
+/// <c>LocalManifestProvider</c>.
+/// </remarks>
+public interface ITranslatableScope
+{
+    /// <summary>
+    /// Translates <paramref name="requestedScope"/> into the scope this provider expects, or
+    /// returns <paramref name="requestedScope"/> unchanged when no translation is necessary.
+    /// </summary>
+    IGenerationScope Translate(IGenerationScope requestedScope);
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ManifestReferenceInfo.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ManifestReferenceInfo.cs
@@ -1,0 +1,153 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// A scope-bound, resolvable pointer to a manifest (Manifest v2 phase P1, gap G6). Splits the
+/// scope-agnostic <c>ManifestReference</c> (the question — "which subject") from the concrete
+/// <see cref="IGenerationScope"/> the question is being asked against (the answer's coordinates),
+/// enabling cross-provider translation (<see cref="ITranslatableScope"/>) and BCDR-style targets
+/// (<see cref="ManifestReferenceTarget"/>) without changing the reference's declaration.
+/// </summary>
+public abstract class ManifestReferenceInfo
+{
+    private static readonly IReadOnlyList<Exception> NoErrors = Array.Empty<Exception>();
+
+    /// <summary>Optional observation sink notified whenever <see cref="GetManifest"/> resolves successfully.</summary>
+    public static IManifestObservationSink? ObservationSink { get; set; }
+
+    protected ManifestReferenceInfo(IManifestProvider provider, IGenerationScope scope, string subject, string? parentSubject)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        this.Provider = provider;
+        this.Scope = scope;
+        this.Subject = subject;
+        this.ParentSubject = parentSubject;
+    }
+
+    /// <summary>The provider this reference resolves against.</summary>
+    public IManifestProvider Provider { get; }
+
+    /// <summary>The Generation Scope this reference resolves within.</summary>
+    public IGenerationScope Scope { get; }
+
+    /// <summary>The referenced manifest's subject identity.</summary>
+    public string Subject { get; }
+
+    /// <summary>The optional parent manifest subject that scopes <see cref="Subject"/>.</summary>
+    public string? ParentSubject { get; }
+
+    /// <summary>The expected manifest CLR type for this reference.</summary>
+    public abstract Type GetManifestType();
+
+    /// <summary>
+    /// Fetches the referenced manifest (untyped), notifying <see cref="ObservationSink"/> when
+    /// resolution succeeds. Returns <see langword="null"/> when the subject cannot be found or
+    /// the stored value does not match <see cref="GetManifestType"/>.
+    /// </summary>
+    public abstract object? GetManifest();
+
+    /// <summary>
+    /// Validates that this reference resolves without throwing (Manifest v2 phase P2, gap G10).
+    /// Returns an empty sequence when valid; otherwise one or more descriptive exceptions
+    /// (dangling subject, type mismatch) suitable for aggregation into a pre-render validation
+    /// failure.
+    /// </summary>
+    public virtual IEnumerable<Exception> ValidateNoThrow()
+    {
+        if (!this.Provider.HasManifestBySubject(this.Scope, this.Subject, this.ParentSubject))
+        {
+            return new Exception[]
+            {
+                new InvalidOperationException(
+                    $"Dangling manifest reference: subject '{this.Subject}' " +
+                    (this.ParentSubject is { } parent ? $"(parent '{parent}') " : string.Empty) +
+                    $"was not found in scope '{this.Scope.GetIdentifier()}' via provider '{this.Provider.ProviderKind}'."),
+            };
+        }
+
+        return NoErrors;
+    }
+
+    /// <summary>Returns a stable identifier combining provider/scope/type/subject, suitable for logging and ordering edges.</summary>
+    public string GetIdentifier() =>
+        this.ParentSubject is { } parent
+            ? $"{this.Provider.ProviderKind}/{this.Scope.GetIdentifier()}/{this.GetManifestType().Name}/{parent}/{this.Subject}"
+            : $"{this.Provider.ProviderKind}/{this.Scope.GetIdentifier()}/{this.GetManifestType().Name}/{this.Subject}";
+}
+
+/// <inheritdoc cref="ManifestReferenceInfo"/>
+/// <typeparam name="TManifest">The expected manifest payload type.</typeparam>
+public sealed class ManifestReferenceInfo<TManifest> : ManifestReferenceInfo
+    where TManifest : class, IManifest
+{
+    private readonly string? _referrerIdentifier;
+
+    public ManifestReferenceInfo(
+        IManifestProvider provider,
+        IGenerationScope scope,
+        string subject,
+        string? parentSubject = null,
+        string? referrerIdentifier = null)
+        : base(provider, scope, subject, parentSubject)
+    {
+        _referrerIdentifier = referrerIdentifier;
+    }
+
+    /// <inheritdoc/>
+    public override Type GetManifestType() => typeof(TManifest);
+
+    /// <summary>Fetches and casts the referenced manifest to <typeparamref name="TManifest"/>.</summary>
+    public TManifest? GetTypedManifest()
+    {
+        if (!this.Provider.TryGetManifest(this.Scope, this.Subject, this.ParentSubject, out var raw))
+        {
+            return null;
+        }
+
+        if (raw is not TManifest typed)
+        {
+            return null;
+        }
+
+        if (_referrerIdentifier is { } referrer && ObservationSink is { } sink)
+        {
+            sink.OnResolved(new ManifestOrderingEdge(referrer, this.GetIdentifier()));
+        }
+
+        return typed;
+    }
+
+    /// <inheritdoc/>
+    public override object? GetManifest() => this.GetTypedManifest();
+
+    /// <inheritdoc/>
+    public override IEnumerable<Exception> ValidateNoThrow()
+    {
+        if (!this.Provider.TryGetManifest(this.Scope, this.Subject, this.ParentSubject, out var raw))
+        {
+            return new Exception[]
+            {
+                new InvalidOperationException(
+                    $"Dangling manifest reference: subject '{this.Subject}' " +
+                    (this.ParentSubject is { } parent ? $"(parent '{parent}') " : string.Empty) +
+                    $"of type '{typeof(TManifest).Name}' was not found in scope '{this.Scope.GetIdentifier()}' " +
+                    $"via provider '{this.Provider.ProviderKind}'."),
+            };
+        }
+
+        if (raw is not TManifest)
+        {
+            return new Exception[]
+            {
+                new InvalidOperationException(
+                    $"Manifest reference type mismatch: subject '{this.Subject}' " +
+                    (this.ParentSubject is { } parent ? $"(parent '{parent}') " : string.Empty) +
+                    $"resolved to '{raw?.GetType().Name ?? "null"}' but reference expects '{typeof(TManifest).Name}'."),
+            };
+        }
+
+        return Array.Empty<Exception>();
+    }
+}

--- a/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ManifestReferenceTarget.cs
+++ b/src/v2/UTMO.Text.FileGenerator.Abstract/Contracts/ManifestReferenceTarget.cs
@@ -1,0 +1,19 @@
+namespace UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// The resolution target for a <c>ManifestReference</c> relative to the requesting
+/// <see cref="IGenerationScope"/> (Manifest v2 phase P4, gap G9).
+/// </summary>
+public enum ManifestReferenceTarget
+{
+    /// <summary>Resolve within the requesting scope itself. Preserves v1 behavior exactly.</summary>
+    ThisScope = 0,
+
+    /// <summary>
+    /// Resolve against a provider-defined "paired" scope coordinate (e.g. a BCDR failover
+    /// region/data-center pair). Providers that support pairing must register the paired
+    /// coordinate and implement <see cref="ITranslatableScope"/>; the base framework has no
+    /// built-in notion of which coordinate is "paired" for a given provider.
+    /// </summary>
+    PairedScope = 1,
+}

--- a/src/v2/UTMO.Text.FileGenerator/FeatureFlights.manifest.json
+++ b/src/v2/UTMO.Text.FileGenerator/FeatureFlights.manifest.json
@@ -4,6 +4,9 @@
     "ParallelTemplateRendering": false,
     "LegacyNonPublicTemplateProperties": false,
     "SuppressNonPublicPropertyWarnings": false,
-    "ManifestReferenceResolution": false
+    "ManifestReferenceResolution": false,
+    "ManifestReferenceValidation": false,
+    "ManifestPackaging": false,
+    "GenerationScopes": false
   }
 }

--- a/src/v2/UTMO.Text.FileGenerator/FileGenerator.cs
+++ b/src/v2/UTMO.Text.FileGenerator/FileGenerator.cs
@@ -85,10 +85,14 @@ public class FileGenerator
                 svc.AddScoped<IGeneralFileWriter, DefaultFileWriter.DefaultFileWriter>();
                 svc.AddSingleton<EnvironmentInitPlugin>();
                 svc.AddSingleton<IPipelinePlugin, ManifestIndexBuildingPlugin>();
+                svc.AddSingleton<IPipelinePlugin, ManifestReferenceValidationPlugin>();
                 svc.AddSingleton<IPipelinePlugin, ManifestPipelineProcessor>();
+                svc.AddSingleton<IPipelinePlugin, ManifestPackageEmissionPlugin>();
                 svc.AddSingleton<IRenderingPipelinePlugin, ManifestReferenceResolverPlugin>();
                 svc.AddSingleton<IManifestReferenceIndex, ManifestReferenceIndex>();
                 svc.AddSingleton<IManifestProvider, LocalManifestProvider>();
+                svc.AddSingleton<IGenerationScopeCoordinateRegistry, GenerationScopeCoordinateRegistry>();
+                svc.AddSingleton<InMemoryManifestObservationSink>();
                 svc.AddFeatureManagement();
             });
         

--- a/src/v2/UTMO.Text.FileGenerator/FileGenerator.cs
+++ b/src/v2/UTMO.Text.FileGenerator/FileGenerator.cs
@@ -88,6 +88,7 @@ public class FileGenerator
                 svc.AddSingleton<IPipelinePlugin, ManifestPipelineProcessor>();
                 svc.AddSingleton<IRenderingPipelinePlugin, ManifestReferenceResolverPlugin>();
                 svc.AddSingleton<IManifestReferenceIndex, ManifestReferenceIndex>();
+                svc.AddSingleton<IManifestProvider, LocalManifestProvider>();
                 svc.AddFeatureManagement();
             });
         

--- a/src/v2/UTMO.Text.FileGenerator/FileGeneratorHost.cs
+++ b/src/v2/UTMO.Text.FileGenerator/FileGeneratorHost.cs
@@ -27,7 +27,7 @@ public class FileGeneratorHost : IHostedService
 
     public int ExitCode => this.ExitCodeHolder.ExitCode;
 
-    public FileGeneratorHost(IServiceProvider provider, ILogger<FileGeneratorHost> logger, IGeneralFileWriter fileWriter, EnvironmentInitPlugin initPlugin, IHostApplicationLifetime lifetime, GenerationExitCodeHolder exitCodeHolder)
+    public FileGeneratorHost(IServiceProvider provider, ILogger<FileGeneratorHost> logger, IGeneralFileWriter fileWriter, EnvironmentInitPlugin initPlugin, IHostApplicationLifetime lifetime, GenerationExitCodeHolder exitCodeHolder, InMemoryManifestObservationSink? observationSink = null)
     {
         this.Logger = logger;
         this.FileWriter = fileWriter;
@@ -40,6 +40,10 @@ public class FileGeneratorHost : IHostedService
         this.InitPlugin = initPlugin;
         this.Lifetime = lifetime;
         this.ExitCodeHolder = exitCodeHolder;
+
+        // Wire the default observation sink (Manifest v2 phase P4, gap G8) so
+        // ManifestReferenceInfo<T> resolutions are recorded for dependency-ordering purposes.
+        ManifestReferenceInfo.ObservationSink = observationSink ?? new InMemoryManifestObservationSink();
     }
 
     private IEnumerable<ITemplateGenerationEnvironment> Environments { get; }

--- a/src/v2/UTMO.Text.FileGenerator/Models/ArtifactManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ArtifactManifestProvider.cs
@@ -1,0 +1,149 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using Newtonsoft.Json.Linq;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// A read-only <see cref="IManifestProvider"/> that resolves manifest references against a
+/// published, portable **Manifest Package** (see <c>ManifestPackageEmissionPlugin</c> and the
+/// <c>Manifests.v2</c> wiki design doc, §6) produced by *another* project's generation run
+/// (Manifest v2 phase P3, gap G5/G4). This is what makes manifest references portable across
+/// repositories: an ARM project can reference subjects from a DSC project's published package
+/// with no source dependency on the DSC project.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Construct with the directory containing a <c>manifest-package.json</c> file (typically the
+/// <c>Manifests/</c> output folder of the producing project, or the contents of a restored
+/// Manifest Package NuGet package). The package is parsed once, eagerly, at construction time.
+/// </para>
+/// <para>
+/// Only the <see cref="IGenerationScope.Environment"/> dimension is matched against the
+/// package's recorded environment; additional coordinates are reserved for future phases.
+/// </para>
+/// </remarks>
+public sealed class ArtifactManifestProvider : IManifestProvider
+{
+    private readonly string _environment;
+    private readonly IReadOnlyDictionary<string, JObject> _bySubjectKey;
+    private readonly IReadOnlyDictionary<string, JObject> _byLegacyKey;
+
+    /// <summary>
+    /// Loads a Manifest Package from <paramref name="packageDirectory"/>.
+    /// </summary>
+    /// <param name="packageDirectory">The directory containing <c>manifest-package.json</c>.</param>
+    /// <exception cref="FileNotFoundException">Thrown when <c>manifest-package.json</c> does not exist in <paramref name="packageDirectory"/>.</exception>
+    public ArtifactManifestProvider(string packageDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageDirectory);
+
+        var packagePath = Path.Combine(packageDirectory, "manifest-package.json");
+
+        if (!File.Exists(packagePath))
+        {
+            throw new FileNotFoundException($"Manifest Package descriptor not found at '{packagePath}'.", packagePath);
+        }
+
+        var package = JObject.Parse(File.ReadAllText(packagePath));
+        this._environment = package.Value<string>("Environment") ?? string.Empty;
+
+        var bySubjectKey = new Dictionary<string, JObject>(StringComparer.Ordinal);
+        var byLegacyKey = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in package["Entries"] as JArray ?? new JArray())
+        {
+            var subject = entry.Value<string>("Subject");
+            var parentSubject = entry.Value<string>("ParentSubject");
+            var resourceTypeName = entry.Value<string>("ResourceTypeName");
+            var resourceName = entry.Value<string>("ResourceName");
+            var manifest = entry["Manifest"] as JObject;
+
+            if (string.IsNullOrWhiteSpace(subject) || manifest is null)
+            {
+                continue;
+            }
+
+            bySubjectKey[MakeSubjectKey(subject, parentSubject)] = manifest;
+
+            if (!string.IsNullOrWhiteSpace(resourceTypeName) && !string.IsNullOrWhiteSpace(resourceName))
+            {
+                byLegacyKey[$"{resourceTypeName}/{resourceName}"] = manifest;
+            }
+        }
+
+        this._bySubjectKey = bySubjectKey;
+        this._byLegacyKey = byLegacyKey;
+    }
+
+    /// <inheritdoc/>
+    public string ProviderKind => "artifact";
+
+    /// <inheritdoc/>
+    public void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData) =>
+        throw new NotSupportedException("ArtifactManifestProvider is read-only. Publish manifests via the producing project's own Manifest Package emission.");
+
+    /// <inheritdoc/>
+    public bool TryResolveProperty(IGenerationScope scope, string resourceTypeName, string resourceName, string propertyPath, out object? value)
+    {
+        if (!this.MatchesEnvironment(scope) || !this._byLegacyKey.TryGetValue($"{resourceTypeName}/{resourceName}", out var manifest))
+        {
+            value = null;
+            return false;
+        }
+
+        return TryNavigate(manifest, propertyPath, out value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasManifest(IGenerationScope scope, string resourceTypeName, string resourceName) =>
+        this.MatchesEnvironment(scope) && this._byLegacyKey.ContainsKey($"{resourceTypeName}/{resourceName}");
+
+    /// <inheritdoc/>
+    public void StoreManifestBySubject(IGenerationScope scope, string subject, string? parentManifest, object? manifestData) =>
+        throw new NotSupportedException("ArtifactManifestProvider is read-only. Publish manifests via the producing project's own Manifest Package emission.");
+
+    /// <inheritdoc/>
+    public bool TryResolveBySubject(IGenerationScope scope, string subject, string? parentManifest, string propertyPath, out object? value)
+    {
+        if (!this.MatchesEnvironment(scope) || !this._bySubjectKey.TryGetValue(MakeSubjectKey(subject, parentManifest), out var manifest))
+        {
+            value = null;
+            return false;
+        }
+
+        return TryNavigate(manifest, propertyPath, out value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasManifestBySubject(IGenerationScope scope, string subject, string? parentManifest) =>
+        this.MatchesEnvironment(scope) && this._bySubjectKey.ContainsKey(MakeSubjectKey(subject, parentManifest));
+
+    private bool MatchesEnvironment(IGenerationScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        return string.Equals(scope.Environment, this._environment, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string MakeSubjectKey(string subject, string? parentSubject) =>
+        string.IsNullOrWhiteSpace(parentSubject) ? subject : $"{parentSubject}|{subject}";
+
+    private static bool TryNavigate(JObject manifest, string propertyPath, out object? value)
+    {
+        if (string.IsNullOrEmpty(propertyPath))
+        {
+            value = manifest;
+            return true;
+        }
+
+        var token = manifest.SelectToken(propertyPath);
+
+        if (token is null)
+        {
+            value = null;
+            return false;
+        }
+
+        value = token.ToObject<object>();
+        return true;
+    }
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/ArtifactManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ArtifactManifestProvider.cs
@@ -37,7 +37,7 @@ public sealed class ArtifactManifestProvider : IManifestProvider
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageDirectory);
 
-        var packagePath = Path.Combine(packageDirectory, "manifest-package.json");
+        var packagePath = Path.Join(packageDirectory, "manifest-package.json");
 
         if (!File.Exists(packagePath))
         {
@@ -47,7 +47,7 @@ public sealed class ArtifactManifestProvider : IManifestProvider
         var package = JObject.Parse(File.ReadAllText(packagePath));
         this._environment = package.Value<string>("Environment") ?? string.Empty;
 
-        var bySubjectKey = new Dictionary<string, JObject>(StringComparer.Ordinal);
+        var bySubjectKey = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
         var byLegacyKey = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var entry in package["Entries"] as JArray ?? new JArray())
@@ -124,8 +124,22 @@ public sealed class ArtifactManifestProvider : IManifestProvider
         return string.Equals(scope.Environment, this._environment, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string MakeSubjectKey(string subject, string? parentSubject) =>
-        string.IsNullOrWhiteSpace(parentSubject) ? subject : $"{parentSubject}|{subject}";
+    private static string MakeSubjectKey(string subject, string? parentSubject)
+    {
+        // Encode components with a case-stable (hex) scheme so the '|' separator and casing
+        // differences cannot cause distinct (parent, subject) tuples to collide, matching the
+        // key construction used by ManifestReferenceIndex.MakeSubjectKey and its
+        // OrdinalIgnoreCase key comparer.
+        var encodedSubject = EncodeKeyComponent(subject);
+        var encodedParent = string.IsNullOrWhiteSpace(parentSubject)
+            ? string.Empty
+            : EncodeKeyComponent(parentSubject);
+
+        return $"{encodedParent}|{encodedSubject}";
+    }
+
+    private static string EncodeKeyComponent(string value) =>
+        Convert.ToHexStringLower(System.Text.Encoding.UTF8.GetBytes(value));
 
     private static bool TryNavigate(JObject manifest, string propertyPath, out object? value)
     {

--- a/src/v2/UTMO.Text.FileGenerator/Models/GenerationScope.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/GenerationScope.cs
@@ -40,7 +40,7 @@ public sealed class GenerationScope : IGenerationScope
     public static GenerationScope ForEnvironment(string environment) => new(environment);
 
     /// <inheritdoc/>
-    public bool TryGetCoordinate(string dimension, out string value)
+    public bool TryGetCoordinate(string dimension, out string? value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dimension);
 
@@ -50,7 +50,7 @@ public sealed class GenerationScope : IGenerationScope
             return true;
         }
 
-        return this.Coordinates.TryGetValue(dimension, out value!);
+        return this.Coordinates.TryGetValue(dimension, out value);
     }
 
     /// <inheritdoc/>

--- a/src/v2/UTMO.Text.FileGenerator/Models/GenerationScope.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/GenerationScope.cs
@@ -1,0 +1,73 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using System.Collections.ObjectModel;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <inheritdoc cref="IGenerationScope"/>
+public sealed class GenerationScope : IGenerationScope
+{
+    private static readonly IReadOnlyDictionary<string, string> EmptyCoordinates =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Initializes a new <see cref="GenerationScope"/>.
+    /// </summary>
+    /// <param name="environment">The mandatory environment dimension. Cannot be null/whitespace.</param>
+    /// <param name="coordinates">
+    /// Optional additional provider-declared coordinates (e.g. <c>{ "DataCenter", "EUS" }</c>).
+    /// Coordinate names are matched case-insensitively.
+    /// </param>
+    public GenerationScope(string environment, IReadOnlyDictionary<string, string>? coordinates = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(environment);
+
+        this.Environment = environment;
+        this.Coordinates = coordinates is { Count: > 0 }
+            ? new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(coordinates, StringComparer.OrdinalIgnoreCase))
+            : EmptyCoordinates;
+    }
+
+    /// <inheritdoc/>
+    public string Environment { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> Coordinates { get; }
+
+    /// <summary>
+    /// Creates a v1-parity scope containing only the <see cref="Environment"/> dimension.
+    /// Resolution against this scope reproduces v1's environment-only behavior exactly.
+    /// </summary>
+    public static GenerationScope ForEnvironment(string environment) => new(environment);
+
+    /// <inheritdoc/>
+    public bool TryGetCoordinate(string dimension, out string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dimension);
+
+        if (string.Equals(dimension, nameof(this.Environment), StringComparison.OrdinalIgnoreCase))
+        {
+            value = this.Environment;
+            return true;
+        }
+
+        return this.Coordinates.TryGetValue(dimension, out value!);
+    }
+
+    /// <inheritdoc/>
+    public string GetIdentifier()
+    {
+        if (this.Coordinates.Count == 0)
+        {
+            return this.Environment;
+        }
+
+        var orderedCoordinates = this.Coordinates
+                                      .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                                      .Select(kvp => $"{kvp.Key}={kvp.Value}");
+
+        return $"{this.Environment}/{string.Join('/', orderedCoordinates)}";
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => this.GetIdentifier();
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/GenerationScopeCoordinateRegistry.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/GenerationScopeCoordinateRegistry.cs
@@ -1,0 +1,71 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using System.Collections.Concurrent;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <inheritdoc cref="IGenerationScopeCoordinateRegistry"/>
+/// <remarks>
+/// Pre-registers the mandatory <c>"Environment"</c> coordinate under owner kind <c>"core"</c>.
+/// Registered as a singleton so provider packages can register their coordinates once at
+/// startup (Manifest v2 phase P4, gap G2) and have registration conflicts fail fast rather than
+/// surface as confusing scope-resolution errors later.
+/// </remarks>
+public sealed class GenerationScopeCoordinateRegistry : IGenerationScopeCoordinateRegistry
+{
+    public const string CoreOwnerKind = "core";
+    public const string EnvironmentCoordinateName = "Environment";
+
+    private readonly ConcurrentDictionary<string, GenerationScopeCoordinate> _coordinates =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public GenerationScopeCoordinateRegistry()
+    {
+        // Pre-register the mandatory Environment dimension; every IGenerationScope already
+        // carries it, so it must always be considered "known".
+        this._coordinates[EnvironmentCoordinateName] =
+            new GenerationScopeCoordinate(EnvironmentCoordinateName, CoreOwnerKind, Required: true);
+    }
+
+    /// <inheritdoc/>
+    public void Register(GenerationScopeCoordinate coordinate)
+    {
+        ArgumentNullException.ThrowIfNull(coordinate);
+        ArgumentException.ThrowIfNullOrWhiteSpace(coordinate.Name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(coordinate.OwnerProviderKind);
+
+        this._coordinates.AddOrUpdate(
+            coordinate.Name,
+            coordinate,
+            (_, existing) =>
+            {
+                if (!string.Equals(existing.OwnerProviderKind, coordinate.OwnerProviderKind, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Generation Scope coordinate '{coordinate.Name}' is already registered to provider " +
+                        $"'{existing.OwnerProviderKind}' and cannot be re-registered to provider " +
+                        $"'{coordinate.OwnerProviderKind}'. Each coordinate name must be owned by exactly one provider.");
+                }
+
+                // Same name + same owner: allow idempotent re-registration, honoring the more
+                // restrictive Required flag if the two declarations disagree.
+                return existing with { Required = existing.Required || coordinate.Required };
+            });
+    }
+
+    /// <inheritdoc/>
+    public bool IsRegistered(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return this._coordinates.ContainsKey(name);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGet(string name, out GenerationScopeCoordinate? coordinate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return this._coordinates.TryGetValue(name, out coordinate);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<GenerationScopeCoordinate> All => this._coordinates.Values.ToArray();
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/InMemoryManifestObservationSink.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/InMemoryManifestObservationSink.cs
@@ -1,0 +1,22 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Default in-memory <see cref="IManifestObservationSink"/> that simply records every observed
+/// edge (Manifest v2 phase P4, gap G8). Thread-safe: concurrent renders may observe edges from
+/// multiple resources simultaneously.
+/// </summary>
+public sealed class InMemoryManifestObservationSink : IManifestObservationSink
+{
+    private readonly System.Collections.Concurrent.ConcurrentBag<ManifestOrderingEdge> _edges = new();
+
+    /// <inheritdoc/>
+    public void OnResolved(ManifestOrderingEdge edge) => this._edges.Add(edge);
+
+    /// <summary>All edges observed so far.</summary>
+    public IReadOnlyCollection<ManifestOrderingEdge> Edges => this._edges.ToArray();
+
+    /// <summary>Removes all recorded edges. Used to reset between runs/environments.</summary>
+    public void Clear() => this._edges.Clear();
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
@@ -27,48 +27,49 @@ public sealed class LocalManifestProvider : IManifestProvider
     /// <inheritdoc/>
     public void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         this._index.StoreManifest(resourceTypeName, resourceName, manifestData);
     }
 
     /// <inheritdoc/>
     public bool TryResolveProperty(IGenerationScope scope, string resourceTypeName, string resourceName, string propertyPath, out object? value)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         return this._index.TryResolveProperty(resourceTypeName, resourceName, propertyPath, out value);
     }
 
     /// <inheritdoc/>
     public bool HasManifest(IGenerationScope scope, string resourceTypeName, string resourceName)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         return this._index.HasManifest(resourceTypeName, resourceName);
     }
 
     /// <inheritdoc/>
     public void StoreManifestBySubject(IGenerationScope scope, string subject, string? parentManifest, object? manifestData)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         this._index.StoreManifestBySubject(subject, parentManifest, manifestData);
     }
 
     /// <inheritdoc/>
     public bool TryResolveBySubject(IGenerationScope scope, string subject, string? parentManifest, string propertyPath, out object? value)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         return this._index.TryResolveBySubject(subject, parentManifest, propertyPath, out value);
     }
 
     /// <inheritdoc/>
     public bool HasManifestBySubject(IGenerationScope scope, string subject, string? parentManifest)
     {
-        this.BeginScope(scope);
+        using var _ = this.BeginScope(scope);
         return this._index.HasManifestBySubject(subject, parentManifest);
     }
 
-    private void BeginScope(IGenerationScope scope)
+    private IDisposable BeginScope(IGenerationScope scope)
     {
         ArgumentNullException.ThrowIfNull(scope);
-        this._index.BeginEnvironmentScope(scope.Environment);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope.Environment);
+        return this._index.BeginEnvironmentScope(scope.Environment);
     }
 }

--- a/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
@@ -25,6 +25,9 @@ public sealed class LocalManifestProvider : IManifestProvider
     }
 
     /// <inheritdoc/>
+    public string ProviderKind => "local";
+
+    /// <inheritdoc/>
     public void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData)
     {
         using var _ = this.BeginScope(scope);

--- a/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/LocalManifestProvider.cs
@@ -1,0 +1,74 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Default <see cref="IManifestProvider"/> implementation that wraps the existing
+/// <see cref="IManifestReferenceIndex"/>, translating an explicit <see cref="IGenerationScope"/>
+/// into the index's ambient environment scope (<see cref="IManifestReferenceIndex.BeginEnvironmentScope"/>).
+/// </summary>
+/// <remarks>
+/// This is the "local" manifest provider called out in the Manifest v2 design (issue #57, phase
+/// P0): it is a behavior-preserving adapter — all storage/lookup mechanics remain exactly as they
+/// were in v1, only the scoping input changes from ambient <c>AsyncLocal</c> state to an explicit
+/// <see cref="IGenerationScope"/> parameter. Only the <see cref="IGenerationScope.Environment"/>
+/// dimension is honored today; additional coordinates are reserved for future Generation Scope
+/// phases (P4) and are currently ignored by this provider.
+/// </remarks>
+public sealed class LocalManifestProvider : IManifestProvider
+{
+    private readonly IManifestReferenceIndex _index;
+
+    public LocalManifestProvider(IManifestReferenceIndex index)
+    {
+        this._index = index;
+    }
+
+    /// <inheritdoc/>
+    public void StoreManifest(IGenerationScope scope, string resourceTypeName, string resourceName, object? manifestData)
+    {
+        this.BeginScope(scope);
+        this._index.StoreManifest(resourceTypeName, resourceName, manifestData);
+    }
+
+    /// <inheritdoc/>
+    public bool TryResolveProperty(IGenerationScope scope, string resourceTypeName, string resourceName, string propertyPath, out object? value)
+    {
+        this.BeginScope(scope);
+        return this._index.TryResolveProperty(resourceTypeName, resourceName, propertyPath, out value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasManifest(IGenerationScope scope, string resourceTypeName, string resourceName)
+    {
+        this.BeginScope(scope);
+        return this._index.HasManifest(resourceTypeName, resourceName);
+    }
+
+    /// <inheritdoc/>
+    public void StoreManifestBySubject(IGenerationScope scope, string subject, string? parentManifest, object? manifestData)
+    {
+        this.BeginScope(scope);
+        this._index.StoreManifestBySubject(subject, parentManifest, manifestData);
+    }
+
+    /// <inheritdoc/>
+    public bool TryResolveBySubject(IGenerationScope scope, string subject, string? parentManifest, string propertyPath, out object? value)
+    {
+        this.BeginScope(scope);
+        return this._index.TryResolveBySubject(subject, parentManifest, propertyPath, out value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasManifestBySubject(IGenerationScope scope, string subject, string? parentManifest)
+    {
+        this.BeginScope(scope);
+        return this._index.HasManifestBySubject(subject, parentManifest);
+    }
+
+    private void BeginScope(IGenerationScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        this._index.BeginEnvironmentScope(scope.Environment);
+    }
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestOrderingResolver.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestOrderingResolver.cs
@@ -49,21 +49,22 @@ public static class ManifestOrderingResolver
             inDegree[edge.ReferrerIdentifier]++;
         }
 
-        var ready = new Queue<string>(inDegree.Where(kvp => kvp.Value == 0).Select(kvp => kvp.Key).OrderBy(k => k, StringComparer.Ordinal));
+        var ready = new SortedSet<string>(inDegree.Where(kvp => kvp.Value == 0).Select(kvp => kvp.Key), StringComparer.Ordinal);
         var order = new List<string>(inDegree.Count);
 
         while (ready.Count > 0)
         {
-            var node = ready.Dequeue();
+            var node = ready.Min!;
+            ready.Remove(node);
             order.Add(node);
 
-            foreach (var dependent in dependents[node].OrderBy(d => d, StringComparer.Ordinal))
+            foreach (var dependent in dependents[node])
             {
                 inDegree[dependent]--;
 
                 if (inDegree[dependent] == 0)
                 {
-                    ready.Enqueue(dependent);
+                    ready.Add(dependent);
                 }
             }
         }

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestOrderingResolver.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestOrderingResolver.cs
@@ -1,0 +1,100 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Computes a canonical topological ordering from observed manifest dependency edges plus any
+/// provider-contributed supplemental edges (Manifest v2 phase P4, gap G8). The base framework
+/// owns this computation; providers only contribute edges via
+/// <see cref="IManifestOrderingContributor"/> or by having their references observed through
+/// <see cref="IManifestObservationSink"/>.
+/// </summary>
+/// <remarks>
+/// Uses Kahn's algorithm. Nodes that never appear as an edge endpoint are not included in the
+/// result — callers that need a total order over "all manifests" (not just those with declared
+/// dependencies) should union this order with the full manifest identifier set and treat
+/// unordered manifests as free to run first.
+/// </remarks>
+public static class ManifestOrderingResolver
+{
+    /// <summary>
+    /// Computes a topological order over all node identifiers referenced by <paramref name="edges"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the edges contain a cycle.</exception>
+    public static IReadOnlyList<string> ComputeOrder(IEnumerable<ManifestOrderingEdge> edges)
+    {
+        ArgumentNullException.ThrowIfNull(edges);
+
+        // dependents[x] = manifests that depend on x (x must come before them)
+        var dependents = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var inDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        void EnsureNode(string id)
+        {
+            if (!dependents.ContainsKey(id))
+            {
+                dependents[id] = new List<string>();
+            }
+
+            inDegree.TryAdd(id, 0);
+        }
+
+        foreach (var edge in edges)
+        {
+            EnsureNode(edge.ReferrerIdentifier);
+            EnsureNode(edge.ReferencedIdentifier);
+
+            // ReferencedIdentifier must be produced before ReferrerIdentifier.
+            dependents[edge.ReferencedIdentifier].Add(edge.ReferrerIdentifier);
+            inDegree[edge.ReferrerIdentifier]++;
+        }
+
+        var ready = new Queue<string>(inDegree.Where(kvp => kvp.Value == 0).Select(kvp => kvp.Key).OrderBy(k => k, StringComparer.Ordinal));
+        var order = new List<string>(inDegree.Count);
+
+        while (ready.Count > 0)
+        {
+            var node = ready.Dequeue();
+            order.Add(node);
+
+            foreach (var dependent in dependents[node].OrderBy(d => d, StringComparer.Ordinal))
+            {
+                inDegree[dependent]--;
+
+                if (inDegree[dependent] == 0)
+                {
+                    ready.Enqueue(dependent);
+                }
+            }
+        }
+
+        if (order.Count != inDegree.Count)
+        {
+            var cyclic = inDegree.Keys.Except(order).OrderBy(k => k, StringComparer.Ordinal);
+            throw new InvalidOperationException(
+                $"Manifest ordering failed: a dependency cycle was detected involving: {string.Join(", ", cyclic)}.");
+        }
+
+        return order;
+    }
+
+    /// <summary>
+    /// Computes the order from an <see cref="InMemoryManifestObservationSink"/> plus any
+    /// registered <see cref="IManifestOrderingContributor"/>s.
+    /// </summary>
+    public static IReadOnlyList<string> ComputeOrder(
+        InMemoryManifestObservationSink sink,
+        IEnumerable<IManifestOrderingContributor>? contributors = null)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+
+        var edges = sink.Edges.AsEnumerable();
+
+        if (contributors is not null)
+        {
+            edges = edges.Concat(contributors.SelectMany(c => c.GetEdges()));
+        }
+
+        return ComputeOrder(edges);
+    }
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
@@ -54,13 +54,22 @@ public class ManifestReference
         ArgumentException.ThrowIfNullOrWhiteSpace(subject);
 
         this.Subject        = subject;
-        this.ParentManifest = parentManifest;
+        // Normalize a whitespace-only parent to null so it matches the "root scope" semantics
+        // used by ManifestReferenceIndex/IManifestProvider, keeping DescribeTarget() and
+        // validation diagnostics consistent with actual resolution behavior.
+        this.ParentManifest = string.IsNullOrWhiteSpace(parentManifest) ? null : parentManifest;
+        // Not used for subject-based resolution, but required members must still be assigned
+        // to satisfy the [SetsRequiredMembers] contract on this constructor.
+        this.ResourceTypeName = string.Empty;
+        this.ResourceName     = string.Empty;
     }
 
     /// <summary>
     /// Initializes an empty manifest reference for the legacy object-initializer form that
     /// identifies the target by <see cref="ResourceTypeName"/>/<see cref="ResourceName"/>.
-    /// Prefer the subject-based constructor for new code.
+    /// Prefer the subject-based constructor for new code. <see cref="ResourceTypeName"/> and
+    /// <see cref="ResourceName"/> are <see langword="required"/> so this form cannot be
+    /// constructed without identifying the target resource.
     /// </summary>
     public ManifestReference()
     {
@@ -73,10 +82,10 @@ public class ManifestReference
     public string? ParentManifest { get; init; }
 
     /// <summary>The <see cref="ITemplateModel.ResourceTypeName"/> of the resource to look up (legacy resolution).</summary>
-    public string ResourceTypeName { get; init; } = string.Empty;
+    public required string ResourceTypeName { get; init; }
 
     /// <summary>The <see cref="ITemplateModel.ResourceName"/> of the resource to look up (legacy resolution).</summary>
-    public string ResourceName { get; init; } = string.Empty;
+    public required string ResourceName { get; init; }
 
     /// <summary>
     /// A dot-separated path to the property within the manifest object returned by

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
@@ -95,6 +95,12 @@ public class ManifestReference
     public string? DefaultValue { get; init; }
 
     /// <summary>
+    /// The scope-resolution target for this reference (Manifest v2 phase P4, gap G9). Defaults
+    /// to <see cref="ManifestReferenceTarget.ThisScope"/>, which preserves v1 behavior exactly.
+    /// </summary>
+    public ManifestReferenceTarget Target { get; init; } = ManifestReferenceTarget.ThisScope;
+
+    /// <summary>
     /// A human-readable description of this reference's target, used in diagnostic logging.
     /// </summary>
     internal virtual string DescribeTarget() =>
@@ -118,6 +124,25 @@ public class ManifestReference
         this.Subject is { } subject
             ? index.TryResolveBySubject(subject, this.ParentManifest, this.PropertyPath, out value)
             : index.TryResolveProperty(this.ResourceTypeName, this.ResourceName, this.PropertyPath, out value);
+
+    /// <summary>
+    /// Pre-render validation pass (Manifest v2 phase P2, gap G10): returns descriptive
+    /// exceptions when this reference is dangling. The base (subject/legacy, untyped)
+    /// implementation only checks presence; <see cref="ManifestReference{TSourceManifest}"/>
+    /// additionally validates the resolved manifest's type (gap G3).
+    /// </summary>
+    internal virtual IEnumerable<Exception> ValidateNoThrow(IManifestProvider provider, IGenerationScope scope)
+    {
+        var found = this.Subject is { } subject
+            ? provider.HasManifestBySubject(scope, subject, this.ParentManifest)
+            : provider.HasManifest(scope, this.ResourceTypeName, this.ResourceName);
+
+        if (!found)
+        {
+            yield return new InvalidOperationException(
+                $"Dangling manifest reference: {this.DescribeTarget()} was not found in scope '{scope.GetIdentifier()}'.");
+        }
+    }
 }
 
 /// <summary>
@@ -211,5 +236,27 @@ public sealed class ManifestReference<TSourceManifest> : ManifestReference where
 
         value = _propertyMapper(typedSourceManifest);
         return true;
+    }
+
+    /// <inheritdoc/>
+    internal override IEnumerable<Exception> ValidateNoThrow(IManifestProvider provider, IGenerationScope scope)
+    {
+        var found = this.Subject is { } subject
+            ? provider.TryGetManifest(scope, subject, this.ParentManifest, out var raw)
+            : provider.TryResolveProperty(scope, this.ResourceTypeName, this.ResourceName, string.Empty, out raw);
+
+        if (!found)
+        {
+            yield return new InvalidOperationException(
+                $"Dangling manifest reference: {this.DescribeTarget()} was not found in scope '{scope.GetIdentifier()}'.");
+            yield break;
+        }
+
+        if (raw is not TSourceManifest)
+        {
+            yield return new InvalidOperationException(
+                $"Manifest reference type mismatch: {this.DescribeTarget()} resolved to " +
+                $"'{raw?.GetType().Name ?? "null"}' but the reference expects '{typeof(TSourceManifest).Name}'.");
+        }
     }
 }

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReference.cs
@@ -32,18 +32,59 @@ using UTMO.Text.FileGenerator.Abstract.Contracts;
 /// </remarks>
 public class ManifestReference
 {
-    /// <summary>The <see cref="ITemplateModel.ResourceTypeName"/> of the resource to look up.</summary>
-    public required string ResourceTypeName { get; init; }
+    /// <summary>
+    /// Initializes a subject-based manifest reference. This is the preferred way to declare a
+    /// reference: the target manifest is identified purely by its <paramref name="subject"/>
+    /// (optionally scoped by <paramref name="parentManifest"/>) and is resolved at runtime from
+    /// the in-memory manifest index without holding the referenced resource instance.
+    /// </summary>
+    /// <param name="subject">The referenced manifest's subject identity (see <c>IManifestProducer.ManifestSubject</c>).</param>
+    /// <param name="parentManifest">
+    /// The optional parent manifest subject that scopes <paramref name="subject"/>. Pass
+    /// <see langword="null"/> to resolve at the environment root scope.
+    /// </param>
+    /// <remarks>
+    /// By default the entire referenced manifest object is injected into the template context.
+    /// Set <see cref="PropertyPath"/> via an object initializer to inject a single nested value,
+    /// e.g. <c>new ManifestReference("BaseConfig") { PropertyPath = "DependsOn" }</c>.
+    /// </remarks>
+    [SetsRequiredMembers]
+    public ManifestReference(string subject, string? parentManifest = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
 
-    /// <summary>The <see cref="ITemplateModel.ResourceName"/> of the resource to look up.</summary>
-    public required string ResourceName { get; init; }
+        this.Subject        = subject;
+        this.ParentManifest = parentManifest;
+    }
+
+    /// <summary>
+    /// Initializes an empty manifest reference for the legacy object-initializer form that
+    /// identifies the target by <see cref="ResourceTypeName"/>/<see cref="ResourceName"/>.
+    /// Prefer the subject-based constructor for new code.
+    /// </summary>
+    public ManifestReference()
+    {
+    }
+
+    /// <summary>The subject identity of the referenced manifest (subject-based resolution).</summary>
+    public string? Subject { get; init; }
+
+    /// <summary>The optional parent manifest subject that scopes <see cref="Subject"/>.</summary>
+    public string? ParentManifest { get; init; }
+
+    /// <summary>The <see cref="ITemplateModel.ResourceTypeName"/> of the resource to look up (legacy resolution).</summary>
+    public string ResourceTypeName { get; init; } = string.Empty;
+
+    /// <summary>The <see cref="ITemplateModel.ResourceName"/> of the resource to look up (legacy resolution).</summary>
+    public string ResourceName { get; init; } = string.Empty;
 
     /// <summary>
     /// A dot-separated path to the property within the manifest object returned by
     /// <see cref="Abstract.Contracts.IManifestProducer.ToManifest{TManifest}"/>.
-    /// For example <c>"DependsOn"</c> or <c>"Network.SubnetId"</c>.
+    /// For example <c>"DependsOn"</c> or <c>"Network.SubnetId"</c>. An empty value (the default)
+    /// resolves the entire manifest object.
     /// </summary>
-    public required string PropertyPath { get; init; }
+    public string PropertyPath { get; init; } = string.Empty;
 
     /// <summary>
     /// The value to use when the reference cannot be resolved from the in-memory manifest
@@ -52,6 +93,16 @@ public class ManifestReference
     /// string (including the empty string) to treat the reference as <em>optional</em>.
     /// </summary>
     public string? DefaultValue { get; init; }
+
+    /// <summary>
+    /// A human-readable description of this reference's target, used in diagnostic logging.
+    /// </summary>
+    internal virtual string DescribeTarget() =>
+        this.Subject is { } subject
+            ? this.ParentManifest is { } parent
+                ? $"subject '{parent}/{subject}#{this.PropertyPath}'"
+                : $"subject '{subject}#{this.PropertyPath}'"
+            : $"'{this.ResourceTypeName}/{this.ResourceName}#{this.PropertyPath}'";
 
     /// <summary>
     /// Resolves this reference against the in-memory index.
@@ -64,7 +115,9 @@ public class ManifestReference
     /// does not match the expected shape/type so optional-reference fallback behavior can apply.
     /// </returns>
     internal virtual bool TryResolveValue(IManifestReferenceIndex index, out object? value) =>
-        index.TryResolveProperty(this.ResourceTypeName, this.ResourceName, this.PropertyPath, out value);
+        this.Subject is { } subject
+            ? index.TryResolveBySubject(subject, this.ParentManifest, this.PropertyPath, out value)
+            : index.TryResolveProperty(this.ResourceTypeName, this.ResourceName, this.PropertyPath, out value);
 }
 
 /// <summary>
@@ -110,10 +163,41 @@ public sealed class ManifestReference<TSourceManifest> : ManifestReference where
         this.DefaultValue     = defaultValue;
     }
 
+    [SetsRequiredMembers]
+    private ManifestReference(
+        Func<TSourceManifest, object?> propertyMapper,
+        string subject,
+        string? parentManifest,
+        string? defaultValue)
+        : base(subject, parentManifest)
+    {
+        ArgumentNullException.ThrowIfNull(propertyMapper);
+
+        _propertyMapper   = propertyMapper;
+        this.DefaultValue = defaultValue;
+    }
+
+    /// <summary>
+    /// Creates a strongly typed, subject-based manifest reference. The referenced manifest is
+    /// identified by <paramref name="subject"/> (optionally scoped by
+    /// <paramref name="parentManifest"/>) and the injected value is selected via
+    /// <paramref name="propertyMapper"/>.
+    /// </summary>
+    public static ManifestReference<TSourceManifest> BySubject(
+        string subject,
+        string? parentManifest,
+        Func<TSourceManifest, object?> propertyMapper,
+        string? defaultValue = null) =>
+        new(propertyMapper, subject, parentManifest, defaultValue);
+
     /// <inheritdoc />
     internal override bool TryResolveValue(IManifestReferenceIndex index, out object? value)
     {
-        if (!index.TryResolveProperty(this.ResourceTypeName, this.ResourceName, string.Empty, out var sourceManifest))
+        var found = this.Subject is { } subject
+            ? index.TryResolveBySubject(subject, this.ParentManifest, string.Empty, out var sourceManifest)
+            : index.TryResolveProperty(this.ResourceTypeName, this.ResourceName, string.Empty, out sourceManifest);
+
+        if (!found)
         {
             value = null;
             return false;

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
@@ -13,11 +13,24 @@ using System.Text;
 public interface IManifestReferenceIndex
 {
     /// <summary>
-    /// Sets the environment name that scopes all subsequent <see cref="StoreManifest"/>,
-    /// <see cref="TryResolveProperty"/> and <see cref="HasManifest"/> calls within the
-    /// current async execution context.  Call this before building or resolving manifests
-    /// for a specific environment so that data from different environments cannot collide.
+    /// Pushes <paramref name="environmentName"/> as the ambient environment scope for the
+    /// current async execution context, and returns a scope token that restores the previous
+    /// ambient environment when disposed.  Wrap each call in a <see langword="using"/> block
+    /// or statement to guarantee the prior scope is restored even if an exception occurs:
+    /// <code>
+    /// using (index.BeginEnvironmentScope("prod")) { /* build/resolve here */ }
+    /// </code>
+    /// All <see cref="StoreManifest"/>, <see cref="TryResolveProperty"/>,
+    /// <see cref="HasManifest"/>, <see cref="StoreManifestBySubject"/>,
+    /// <see cref="TryResolveBySubject"/> and <see cref="HasManifestBySubject"/> calls made
+    /// within the scope use <paramref name="environmentName"/> to partition data so that
+    /// manifests from different environments cannot collide.
     /// </summary>
+    /// <param name="environmentName">The environment name to activate.  Must not be null or whitespace.</param>
+    /// <returns>
+    /// An <see cref="IDisposable"/> scope token.  Disposing it restores the ambient
+    /// environment that was active before this call.
+    /// </returns>
     IDisposable BeginEnvironmentScope(string environmentName);
 
     /// <summary>

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
@@ -101,8 +101,11 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
     /// <summary>
     /// Builds the storage key for a subject-based manifest. A distinct <c>//subject//</c>
     /// namespace segment keeps subject keys from colliding with legacy
-    /// <c>resourceTypeName/resourceName</c> keys. Subject and parent components are base64
-    /// encoded so values containing <c>/</c> cannot produce ambiguous composite keys.
+    /// <c>resourceTypeName/resourceName</c> keys. Subject and parent components are hex
+    /// encoded (rather than base64) so values containing <c>/</c> cannot produce ambiguous
+    /// composite keys, and so casing differences in the encoded output cannot cause distinct
+    /// subjects/parents to collide under the <see cref="StringComparer.OrdinalIgnoreCase"/>
+    /// comparer used by <see cref="_data"/> (base64's mixed-case alphabet is not case-stable).
     /// </summary>
     private string MakeSubjectKey(string subject, string? parentManifest)
     {
@@ -120,7 +123,7 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
     }
 
     private static string EncodeKeyComponent(string value) =>
-        Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        Convert.ToHexStringLower(Encoding.UTF8.GetBytes(value));
 
     /// <inheritdoc/>
     public void StoreManifest(string resourceTypeName, string resourceName, object? manifestData) =>

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
@@ -40,6 +40,24 @@ public interface IManifestReferenceIndex
     /// <summary>Returns whether a manifest has been stored for the given resource within the current environment scope.</summary>
     bool HasManifest(string resourceTypeName, string resourceName);
 
+    /// <summary>
+    /// Stores the manifest data for the given <paramref name="subject"/> (optionally scoped by
+    /// <paramref name="parentManifest"/>) within the current environment scope. This is the
+    /// storage path used by subject-based manifest references.
+    /// </summary>
+    void StoreManifestBySubject(string subject, string? parentManifest, object? manifestData);
+
+    /// <summary>
+    /// Attempts to navigate <paramref name="propertyPath"/> inside the manifest data stored for
+    /// <paramref name="subject"/> (optionally scoped by <paramref name="parentManifest"/>) within
+    /// the current environment scope. An empty <paramref name="propertyPath"/> resolves the entire
+    /// manifest object.
+    /// </summary>
+    bool TryResolveBySubject(string subject, string? parentManifest, string propertyPath, out object? value);
+
+    /// <summary>Returns whether a manifest has been stored for the given subject/parent within the current environment scope.</summary>
+    bool HasManifestBySubject(string subject, string? parentManifest);
+
     /// <summary>Removes all stored manifests.  Used to reset the index between runs.</summary>
     void Clear();
 }
@@ -73,6 +91,19 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
             ? $"{env}/{resourceTypeName}/{resourceName}"
             : $"{resourceTypeName}/{resourceName}";
 
+    /// <summary>
+    /// Builds the storage key for a subject-based manifest. A distinct <c>//subject//</c>
+    /// namespace segment keeps subject keys from colliding with legacy
+    /// <c>resourceTypeName/resourceName</c> keys.
+    /// </summary>
+    private string MakeSubjectKey(string subject, string? parentManifest)
+    {
+        var scope = string.IsNullOrWhiteSpace(parentManifest) ? subject : $"{parentManifest}/{subject}";
+        return _currentEnvironment.Value is { } env
+            ? $"{env}//subject//{scope}"
+            : $"//subject//{scope}";
+    }
+
     /// <inheritdoc/>
     public void StoreManifest(string resourceTypeName, string resourceName, object? manifestData) =>
         _data[MakeKey(resourceTypeName, resourceName)] = manifestData;
@@ -98,6 +129,30 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
     /// <inheritdoc/>
     public bool HasManifest(string resourceTypeName, string resourceName) =>
         _data.ContainsKey(MakeKey(resourceTypeName, resourceName));
+
+    /// <inheritdoc/>
+    public void StoreManifestBySubject(string subject, string? parentManifest, object? manifestData) =>
+        _data[MakeSubjectKey(subject, parentManifest)] = manifestData;
+
+    /// <inheritdoc/>
+    public bool TryResolveBySubject(
+        string subject,
+        string? parentManifest,
+        string propertyPath,
+        out object? value)
+    {
+        if (!_data.TryGetValue(MakeSubjectKey(subject, parentManifest), out var manifestData))
+        {
+            value = null;
+            return false;
+        }
+
+        return TryNavigatePath(manifestData, propertyPath, out value);
+    }
+
+    /// <inheritdoc/>
+    public bool HasManifestBySubject(string subject, string? parentManifest) =>
+        _data.ContainsKey(MakeSubjectKey(subject, parentManifest));
 
     /// <inheritdoc/>
     public void Clear() => _data.Clear();

--- a/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/ManifestReferenceIndex.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text;
 
 /// <summary>
 /// Stores and retrieves in-memory manifest data indexed by resource type name and resource
@@ -17,7 +18,7 @@ public interface IManifestReferenceIndex
     /// current async execution context.  Call this before building or resolving manifests
     /// for a specific environment so that data from different environments cannot collide.
     /// </summary>
-    void BeginEnvironmentScope(string environmentName);
+    IDisposable BeginEnvironmentScope(string environmentName);
 
     /// <summary>
     /// Stores the manifest data for the given resource within the current environment scope.
@@ -83,8 +84,14 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
-    public void BeginEnvironmentScope(string environmentName) =>
+    public IDisposable BeginEnvironmentScope(string environmentName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentName);
+
+        var previousEnvironment = _currentEnvironment.Value;
         _currentEnvironment.Value = environmentName;
+        return new EnvironmentScope(_currentEnvironment, previousEnvironment);
+    }
 
     private string MakeKey(string resourceTypeName, string resourceName) =>
         _currentEnvironment.Value is { } env
@@ -94,15 +101,26 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
     /// <summary>
     /// Builds the storage key for a subject-based manifest. A distinct <c>//subject//</c>
     /// namespace segment keeps subject keys from colliding with legacy
-    /// <c>resourceTypeName/resourceName</c> keys.
+    /// <c>resourceTypeName/resourceName</c> keys. Subject and parent components are base64
+    /// encoded so values containing <c>/</c> cannot produce ambiguous composite keys.
     /// </summary>
     private string MakeSubjectKey(string subject, string? parentManifest)
     {
-        var scope = string.IsNullOrWhiteSpace(parentManifest) ? subject : $"{parentManifest}/{subject}";
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        var encodedSubject = EncodeKeyComponent(subject);
+        var encodedParent = string.IsNullOrWhiteSpace(parentManifest)
+            ? string.Empty
+            : EncodeKeyComponent(parentManifest);
+        var scope = $"{encodedParent}|{encodedSubject}";
+
         return _currentEnvironment.Value is { } env
             ? $"{env}//subject//{scope}"
             : $"//subject//{scope}";
     }
+
+    private static string EncodeKeyComponent(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
     /// <inheritdoc/>
     public void StoreManifest(string resourceTypeName, string resourceName, object? manifestData) =>
@@ -156,6 +174,30 @@ public sealed class ManifestReferenceIndex : IManifestReferenceIndex
 
     /// <inheritdoc/>
     public void Clear() => _data.Clear();
+
+    private sealed class EnvironmentScope : IDisposable
+    {
+        private readonly AsyncLocal<string?> _currentEnvironment;
+        private readonly string? _previousEnvironment;
+        private bool _isDisposed;
+
+        public EnvironmentScope(AsyncLocal<string?> currentEnvironment, string? previousEnvironment)
+        {
+            _currentEnvironment = currentEnvironment;
+            _previousEnvironment = previousEnvironment;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _currentEnvironment.Value = _previousEnvironment;
+            _isDisposed = true;
+        }
+    }
 
     /// <summary>
     /// Traverses a dot-separated <paramref name="path"/> starting from <paramref name="data"/>.

--- a/src/v2/UTMO.Text.FileGenerator/Models/NestedManifestBase.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/NestedManifestBase.cs
@@ -1,0 +1,31 @@
+namespace UTMO.Text.FileGenerator.Models;
+
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+
+/// <summary>
+/// Base class for a manifest that is nested beneath a parent manifest (Manifest v2 phase P4,
+/// gap G7), mirroring ConfigGen's typed subjects-chain nesting. Provider manifest base classes
+/// (e.g. a future <c>DscConfigurationManifestBase</c>) can derive from this to expose their
+/// parent manifest in a strongly typed way instead of only a raw <c>ParentSubject</c> string.
+/// </summary>
+/// <typeparam name="TParent">The parent manifest's identity type.</typeparam>
+public abstract class NestedManifestBase<TParent> : ManifestBase, INestedManifest<TParent>
+    where TParent : class, IManifest
+{
+    private readonly Func<TParent> _parentAccessor;
+
+    /// <param name="parentAccessor">
+    /// A callback that resolves the parent manifest, typically by calling back into an
+    /// <see cref="IManifestProvider"/> with the parent's subject. Invoked lazily by
+    /// <see cref="GetParentManifest"/> rather than eagerly at construction time so a large
+    /// object graph is only walked when actually needed.
+    /// </param>
+    protected NestedManifestBase(Func<TParent> parentAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(parentAccessor);
+        this._parentAccessor = parentAccessor;
+    }
+
+    /// <inheritdoc/>
+    public TParent GetParentManifest() => this._parentAccessor();
+}

--- a/src/v2/UTMO.Text.FileGenerator/Models/TemplateResourceBase.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Models/TemplateResourceBase.cs
@@ -27,6 +27,18 @@ public abstract class TemplateResourceBase : ITemplateModel, IManifestProducer
 
     public virtual bool GenerateManifest { get; } = false;
 
+    /// <summary>
+    /// The stable subject identity used for subject-based manifest reference resolution.
+    /// Defaults to <see cref="ResourceName"/>. Override to provide a distinct, unique subject.
+    /// </summary>
+    public virtual string? ManifestSubject => this.ResourceName;
+
+    /// <summary>
+    /// The optional parent manifest subject that scopes <see cref="ManifestSubject"/>.
+    /// Defaults to <see langword="null"/> (environment root scope).
+    /// </summary>
+    public virtual string? ParentManifestSubject => null;
+
     public virtual Task<TManifest?> ToManifest<TManifest>() where TManifest : class, IManifest
     {
         return Task.FromResult(null as TManifest);

--- a/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestIndexBuildingPlugin.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestIndexBuildingPlugin.cs
@@ -226,7 +226,21 @@ public sealed class ManifestIndexBuildingPlugin : IPipelinePlugin
             var subject = producer.ManifestSubject;
             if (!string.IsNullOrWhiteSpace(subject))
             {
-                _index.StoreManifestBySubject(subject, producer.ParentManifestSubject, manifestData);
+                if (_index.HasManifestBySubject(subject, producer.ParentManifestSubject))
+                {
+                    _logger.LogError(
+                        "Duplicate manifest subject '{Subject}' (parent: '{ParentSubject}') detected while indexing resource " +
+                        "'{ResourceTypeName}/{ResourceName}'. Subject-based references to this subject would resolve " +
+                        "non-deterministically; skipping the overwrite and keeping the first-indexed manifest.",
+                        subject,
+                        producer.ParentManifestSubject,
+                        resource.ResourceTypeName,
+                        resource.ResourceName);
+                }
+                else
+                {
+                    _index.StoreManifestBySubject(subject, producer.ParentManifestSubject, manifestData);
+                }
             }
 
             indexed++;

--- a/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestIndexBuildingPlugin.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestIndexBuildingPlugin.cs
@@ -220,12 +220,22 @@ public sealed class ManifestIndexBuildingPlugin : IPipelinePlugin
         {
             var manifestData = await producer.ToManifest<IManifest>();
             _index.StoreManifest(resource.ResourceTypeName, resource.ResourceName, manifestData);
+
+            // Also store under the producer's subject so subject-based references can resolve
+            // it from anywhere without knowing the resource's type/name.
+            var subject = producer.ManifestSubject;
+            if (!string.IsNullOrWhiteSpace(subject))
+            {
+                _index.StoreManifestBySubject(subject, producer.ParentManifestSubject, manifestData);
+            }
+
             indexed++;
 
             _logger.LogDebug(
-                "Indexed manifest for resource '{ResourceTypeName}/{ResourceName}'.",
+                "Indexed manifest for resource '{ResourceTypeName}/{ResourceName}' (subject: '{Subject}').",
                 resource.ResourceTypeName,
-                resource.ResourceName);
+                resource.ResourceName,
+                subject);
         }
         else
         {

--- a/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceResolverPlugin.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceResolverPlugin.cs
@@ -99,12 +99,10 @@ public sealed class ManifestReferenceResolverPlugin : IRenderingPipelinePlugin
         foreach (var (contextKey, reference) in references)
         {
             _logger.LogDebug(
-                "Resolving manifest reference for context key '{ContextKey}': '{RefTypeName}/{RefName}#{PropertyPath}' " +
+                "Resolving manifest reference for context key '{ContextKey}': {ReferenceTarget} " +
                 "(source: '{SourceTypeName}/{SourceName}').",
                 contextKey,
-                reference.ResourceTypeName,
-                reference.ResourceName,
-                reference.PropertyPath,
+                reference.DescribeTarget(),
                 resource.ResourceTypeName,
                 resource.ResourceName);
 
@@ -114,13 +112,11 @@ public sealed class ManifestReferenceResolverPlugin : IRenderingPipelinePlugin
 
                 _logger.LogDebug(
                     "Manifest reference resolved: context key '{ContextKey}' for resource " +
-                    "'{SourceTypeName}/{SourceName}' → reference '{RefTypeName}/{RefName}#{PropertyPath}'.",
+                    "'{SourceTypeName}/{SourceName}' → reference {ReferenceTarget}.",
                     contextKey,
                     resource.ResourceTypeName,
                     resource.ResourceName,
-                    reference.ResourceTypeName,
-                    reference.ResourceName,
-                    reference.PropertyPath);
+                    reference.DescribeTarget());
             }
             else if (reference.DefaultValue is not null)
             {
@@ -129,30 +125,26 @@ public sealed class ManifestReferenceResolverPlugin : IRenderingPipelinePlugin
 
                 _logger.LogWarning(
                     "Manifest reference unresolved for context key '{ContextKey}' on resource " +
-                    "'{SourceTypeName}/{SourceName}': reference '{RefTypeName}/{RefName}#{PropertyPath}' " +
+                    "'{SourceTypeName}/{SourceName}': reference {ReferenceTarget} " +
                     "was not found in the index. Using declared default value.",
                     contextKey,
                     resource.ResourceTypeName,
                     resource.ResourceName,
-                    reference.ResourceTypeName,
-                    reference.ResourceName,
-                    reference.PropertyPath);
+                    reference.DescribeTarget());
             }
             else
             {
                 // Required reference – generation cannot proceed.
                 _logger.LogError(
                     "Required manifest reference unresolved: context key '{ContextKey}' on resource " +
-                    "'{SourceTypeName}/{SourceName}' references '{RefTypeName}/{RefName}#{PropertyPath}' " +
+                    "'{SourceTypeName}/{SourceName}' references {ReferenceTarget} " +
                     "which was not found in the manifest index. " +
                     "Ensure the referenced resource has GenerateManifest=true and that the ManifestReferenceResolution " +
                     "feature flag is enabled.",
                     contextKey,
                     resource.ResourceTypeName,
                     resource.ResourceName,
-                    reference.ResourceTypeName,
-                    reference.ResourceName,
-                    reference.PropertyPath);
+                    reference.DescribeTarget());
 
                 allResolved = false;
             }

--- a/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceValidationPlugin.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceValidationPlugin.cs
@@ -1,0 +1,162 @@
+﻿using UTMO.Text.FileGenerator.Abstract.Constants;
+
+namespace UTMO.Text.FileGenerator.Plugins;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
+using UTMO.Text.FileGenerator.Abstract;
+using UTMO.Text.FileGenerator.Abstract.Contracts;
+using UTMO.Text.FileGenerator.Constants;
+using UTMO.Text.FileGenerator.Models;
+
+/// <summary>
+/// A <see cref="IPipelinePlugin"/> that runs at <see cref="PluginPosition.Before"/>, after
+/// <see cref="ManifestIndexBuildingPlugin"/>, and validates every declared
+/// <see cref="ManifestReference"/> before any template is rendered (Manifest v2 phase P2, gaps
+/// G3/G10). Dangling subjects and type mismatches are reported here, up front, rather than
+/// silently falling back to <see cref="ManifestReference.DefaultValue"/> at render time or
+/// surfacing mid-render.
+/// </summary>
+/// <remarks>
+/// Gated by the <c>EnableManifestReferenceValidation</c> feature flag, which is additive to
+/// (and requires) <c>EnableManifestReferenceResolution</c>. When disabled the plugin returns
+/// immediately without validating anything, preserving v1/current behavior.
+/// </remarks>
+[SuppressMessage("ReSharper", "TemplateIsNotCompileTimeConstantProblem")]
+[SuppressMessage("Usage", "CA2254:Template should be a static expression")]
+public sealed class ManifestReferenceValidationPlugin : IPipelinePlugin
+{
+    private readonly IFeatureManager _featureManager;
+    private readonly IManifestProvider _provider;
+    private readonly ILogger<ManifestReferenceValidationPlugin> _logger;
+
+    public ManifestReferenceValidationPlugin(
+        IFeatureManager featureManager,
+        IManifestProvider provider,
+        ILogger<ManifestReferenceValidationPlugin> logger)
+    {
+        _featureManager = featureManager;
+        _provider       = provider;
+        _logger         = logger;
+    }
+
+    /// <inheritdoc/>
+    public IGeneralFileWriter? Writer { get; init; }
+
+    /// <inheritdoc/>
+    public ITemplateGenerationEnvironment? Environment { get; init; }
+
+    /// <inheritdoc/>
+    public PluginPosition Position => PluginPosition.Before;
+
+    /// <inheritdoc/>
+    public TimeSpan MaxRuntime => TimeSpan.FromMinutes(5);
+
+    /// <inheritdoc/>
+    public bool RequiresGeneration => false;
+
+    /// <inheritdoc/>
+    public async Task<bool> ProcessPlugin(ITemplateGenerationEnvironment environment)
+    {
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.EnableManifestReferenceResolution) ||
+            !await _featureManager.IsEnabledAsync(FeatureFlags.EnableManifestReferenceValidation))
+        {
+            _logger.LogDebug(
+                "Manifest reference validation is disabled ({FeatureFlag}). Skipping validation for environment '{EnvironmentName}'.",
+                FeatureFlags.EnableManifestReferenceValidation,
+                environment.EnvironmentName);
+            return true;
+        }
+
+        var scope = GenerationScope.ForEnvironment(environment.EnvironmentName);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var failureCount = 0;
+
+        foreach (var resource in environment.Resources)
+        {
+            failureCount += CollectAndValidate(resource, scope, visited);
+        }
+
+        if (failureCount > 0)
+        {
+            _logger.LogError(
+                "Manifest reference validation failed for environment '{EnvironmentName}': {FailureCount} invalid reference(s). See preceding errors for details.",
+                environment.EnvironmentName,
+                failureCount);
+            return false;
+        }
+
+        _logger.LogInformation(
+            "Manifest reference validation passed for environment '{EnvironmentName}'.",
+            environment.EnvironmentName);
+        return true;
+    }
+
+    private int CollectAndValidate(ITemplateModel resource, IGenerationScope scope, HashSet<string> visited)
+    {
+        var resourceKey = $"{resource.ResourceTypeName}/{resource.ResourceName}";
+
+        if (!visited.Add(resourceKey))
+        {
+            return 0;
+        }
+
+        var failureCount = 0;
+
+        foreach (var prop in resource.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            object? value;
+
+            try
+            {
+                value = prop.GetValue(resource);
+            }
+            catch (Exception ex) when (ex is TargetInvocationException or TargetParameterCountException
+                                            or MethodAccessException or ArgumentException
+                                            or TargetException or NotSupportedException)
+            {
+                continue;
+            }
+
+            switch (value)
+            {
+                case ITemplateModel nested:
+                    failureCount += CollectAndValidate(nested, scope, visited);
+                    break;
+
+                case IEnumerable<ITemplateModel> nestedList:
+                {
+                    foreach (var item in nestedList)
+                    {
+                        failureCount += CollectAndValidate(item, scope, visited);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        if (resource is not TemplateResourceBase templateResource)
+        {
+            return failureCount;
+        }
+
+        foreach (var (contextKey, reference) in templateResource.ManifestReferences)
+        {
+            foreach (var error in reference.ValidateNoThrow(_provider, scope))
+            {
+                _logger.LogError(
+                    "Manifest reference validation failed for context key '{ContextKey}' on resource '{ResourceTypeName}/{ResourceName}': {ErrorMessage}",
+                    contextKey,
+                    resource.ResourceTypeName,
+                    resource.ResourceName,
+                    error.Message);
+                failureCount++;
+            }
+        }
+
+        return failureCount;
+    }
+}

--- a/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceValidationPlugin.cs
+++ b/src/v2/UTMO.Text.FileGenerator/Plugins/ManifestReferenceValidationPlugin.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
 using UTMO.Text.FileGenerator.Abstract;
 using UTMO.Text.FileGenerator.Abstract.Contracts;
-using UTMO.Text.FileGenerator.Constants;
 using UTMO.Text.FileGenerator.Models;
 
 /// <summary>

--- a/src/v2/UTMO.Text.FileGenerator/UTMO.Text.FileGenerator.csproj
+++ b/src/v2/UTMO.Text.FileGenerator/UTMO.Text.FileGenerator.csproj
@@ -40,6 +40,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Hosting" />
       <PackageReference Include="Microsoft.FeatureManagement" />
+      <PackageReference Include="Newtonsoft.Json" />
       <PackageReference Include="Serilog" />
       <PackageReference Include="Serilog.Exceptions" />
       <PackageReference Include="Serilog.Extensions.Logging" />


### PR DESCRIPTION
Implements the [Manifests v2 design](https://github.com/UTM-Online/UTMO.Text.FileGenerator/wiki/Manifests.v2) (a provider-agnostic Generation Scope / Manifest / Manifest Reference / Manifest Provider model for DSC, ARM, and future providers) in full for this repository, phases P0 through P4. Phase P5 (ARM/DSC providers actually adopting these seams) is explicitly out of scope here — it is provider-owned future work tracked in those repos.

## Part 1 — Subject-based manifest references

Manifest references could previously only be declared by identifying the target by its `ResourceTypeName`/`ResourceName`, which in practice forced consumers to construct the referenced resource first and read those identity strings off the instance. This adds the intended subject-based form:

```csharp
new ManifestReference(string subject, string? parentManifest)
```

A reference is now declared by a stable, author-chosen **subject** (optionally scoped by a **parentManifest**) and is resolved from the in-memory manifest index at runtime from anywhere, with no object-graph coupling to the referenced resource.

### Changes
- **`IManifestProducer`**: adds `ManifestSubject` and `ParentManifestSubject` as default interface members (non-breaking for external implementers).
- **`TemplateResourceBase`**: `ManifestSubject` defaults to `ResourceName`; both are `virtual`.
- **`ManifestReferenceIndex`**: adds `StoreManifestBySubject` / `TryResolveBySubject` / `HasManifestBySubject`, using a distinct `//subject//` key namespace so subject keys never collide with legacy `type/name` keys.
- **`ManifestReference`**: adds the `(subject, parentManifest)` constructor plus `Subject`/`ParentManifest` and subject-aware resolution (whole manifest by default; set `PropertyPath` for a nested value). `ManifestReference` gains a `BySubject(...)` factory for typed selection.
- **`ManifestIndexBuildingPlugin`**: indexes each producer manifest by subject in addition to the legacy key.
- **`ManifestReferenceResolverPlugin`**: diagnostic logging now describes subject-based targets.

### Backward compatibility
Legacy `ResourceTypeName`/`ResourceName` references (both the property-bag and generic forms) remain fully functional. The feature stays gated behind the `ManifestReferenceResolution` feature flag (default off).

## Part 2 — Phase P0: Generation Scope / Manifest Provider extraction

- **`IGenerationScope` / `GenerationScope`**: a provider-agnostic coordinate set a reference resolves against. Only the mandatory `Environment` dimension is populated in v1 semantics (`GenerationScope.ForEnvironment(...)`), reproducing v1's environment-only resolution byte-for-byte.
- **`IManifestProvider` / `LocalManifestProvider`**: a scope-parameterized facade over the existing `IManifestReferenceIndex`, registered in DI alongside it.

## Part 3 — Phase P1: Typed, scope-bound resolution

- **`ManifestReferenceInfo` / `ManifestReferenceInfo<TManifest>`**: a resolvable pointer that binds a provider, an `IGenerationScope`, and a subject/parent-subject pair. `GetTypedManifest()` resolves and casts; `GetIdentifier()` returns a stable `{providerKind}/{scopeId}/{manifestType}/{subject}` string for logging and ordering.
- **`IManifestIdentity`**: an optional typed identity surface (`ProviderKind`, `Subject`, `ParentSubject`, `Name`, `GetAddress()`) providers can implement without affecting the existing `IManifest` marker interface.
- **`IManifestProvider.TryGetManifest`**: a new default-implemented member routing typed resolution through `TryResolveBySubject`.

## Part 4 — Phase P2: Pre-render reference validation

- **`ManifestReferenceValidationPlugin`**: a `Before`-position pipeline plugin, gated by the new `ManifestReferenceValidation` feature flag (additive to `ManifestReferenceResolution`), that walks every declared reference before rendering and fails fast on dangling subjects or typed-reference type mismatches — instead of surfacing those failures mid-render.
- **`ManifestReference.ValidateNoThrow(...)`**: the underlying non-throwing validation check used by the plugin.

## Part 5 — Phase P3: Portable Manifest Packages

- **`ManifestPackageEmissionPlugin`**: gated by the new `ManifestPackaging` feature flag, emits a self-contained `manifest-package.json` (schema version, provider kind, environment, and every subject-bearing manifest's payload embedded directly) plus a generated `Subjects.g.cs` typo-proof constants class, to `{OutputPath}/Manifests/`.
- **`ArtifactManifestProvider`**: a new read-only `IManifestProvider` that loads a published Manifest Package from another project's output, enabling cross-repository manifest references with no source dependency between producer and consumer.

## Part 6 — Phase P4: Nested manifests, dependency ordering, scope coordinates

- **`INestedManifest<TParent>` / `NestedManifestBase<TParent>`**: typed parent-manifest nesting with lazy parent resolution.
- **`IManifestObservationSink` / `InMemoryManifestObservationSink` / `ManifestOrderingResolver`**: every successful typed reference resolution (when constructed with a referrer identifier) reports a dependency edge; `ManifestOrderingResolver` computes a topological deployment order via Kahn's algorithm (with cycle detection) from those edges plus optional `IManifestOrderingContributor` supplemental edges. Wired into `FileGeneratorHost` via a static observation sink set at startup.
- **`IGenerationScopeCoordinateRegistry` / `GenerationScopeCoordinate`**: declaration-only registration of additional Generation Scope dimensions beyond `Environment`, with fail-fast conflict detection when two providers claim the same coordinate name.
- **`ITranslatableScope` / `ManifestReferenceTarget`**: seams for a provider to translate a foreign scope vocabulary before lookup, and for references to target a provider-defined "paired" scope (e.g. BCDR failover) instead of the requesting scope itself.

## Testing
- Full suite: **297 passed, 8 skipped, 0 failed** on both net9.0 and net10.0 (Debug + Release build clean, 0 warnings).
- 33 new unit tests covering typed resolution/validation, ordering (linear/diamond/cycle), coordinate registry conflicts, and the artifact provider (missing package, subject/legacy resolution, environment mismatch, parent scoping, read-only behavior).
- Retains all prior P0/subject-reference test coverage (`SubjectManifestReferenceTests`, `GenerationScopeTests`, `LocalManifestProviderTests`, end-to-end `FileGeneratorHost` integration test).

## Docs
- `UsingManifestV2.md` wiki doc rewritten to cover typed resolution, pre-render validation, Manifest Packages, nested manifests, dependency ordering, scope coordinates, and to note Phase P5's out-of-scope status.

## Scope note
Phase P5 (ARM/DSC providers actually adopting subject-based references, typed resolution, Manifest Packages, and ordering end-to-end) is intentionally **not** implemented here — this repo owns the framework contracts, not those providers' resource models. It remains tracked as future work in the ARM/DSC provider repositories.

closes #57